### PR TITLE
fix: remove old session cookies on 401 error

### DIFF
--- a/coderd/coderd.go
+++ b/coderd/coderd.go
@@ -737,6 +737,7 @@ func New(options *Options) *API {
 		OAuth2Configs:                 oauthConfigs,
 		RedirectToLogin:               false,
 		DisableSessionExpiryRefresh:   options.DeploymentValues.Sessions.DisableExpiryRefresh.Value(),
+		SecureAuthCookie:              options.DeploymentValues.SecureAuthCookie.Value(),
 		Optional:                      false,
 		SessionTokenFunc:              nil, // Default behavior
 		PostAuthAdditionalHeadersFunc: options.PostAuthAdditionalHeadersFunc,
@@ -747,6 +748,7 @@ func New(options *Options) *API {
 		OAuth2Configs:                 oauthConfigs,
 		RedirectToLogin:               true,
 		DisableSessionExpiryRefresh:   options.DeploymentValues.Sessions.DisableExpiryRefresh.Value(),
+		SecureAuthCookie:              options.DeploymentValues.SecureAuthCookie.Value(),
 		Optional:                      false,
 		SessionTokenFunc:              nil, // Default behavior
 		PostAuthAdditionalHeadersFunc: options.PostAuthAdditionalHeadersFunc,
@@ -757,6 +759,7 @@ func New(options *Options) *API {
 		OAuth2Configs:                 oauthConfigs,
 		RedirectToLogin:               false,
 		DisableSessionExpiryRefresh:   options.DeploymentValues.Sessions.DisableExpiryRefresh.Value(),
+		SecureAuthCookie:              options.DeploymentValues.SecureAuthCookie.Value(),
 		Optional:                      true,
 		SessionTokenFunc:              nil, // Default behavior
 		PostAuthAdditionalHeadersFunc: options.PostAuthAdditionalHeadersFunc,

--- a/coderd/httpmw/apikey.go
+++ b/coderd/httpmw/apikey.go
@@ -86,6 +86,7 @@ type ExtractAPIKeyConfig struct {
 	OAuth2Configs               *OAuth2Configs
 	RedirectToLogin             bool
 	DisableSessionExpiryRefresh bool
+	SecureAuthCookie            bool
 
 	// Optional governs whether the API key is optional. Use this if you want to
 	// allow unauthenticated requests.
@@ -200,10 +201,30 @@ func APIKeyFromRequest(ctx context.Context, db database.Store, sessionTokenFunc 
 // nolint:revive
 func ExtractAPIKey(rw http.ResponseWriter, r *http.Request, cfg ExtractAPIKeyConfig) (*database.APIKey, *rbac.Subject, bool) {
 	ctx := r.Context()
+
+	clearSessionCookie := func() {
+		cookie, err := r.Cookie(codersdk.SessionTokenCookie)
+		if err == nil && cookie != nil {
+			http.SetCookie(rw, &http.Cookie{
+				Name:     codersdk.SessionTokenCookie,
+				Value:    "",
+				Path:     "/",
+				HttpOnly: true,
+				SameSite: http.SameSiteLaxMode,
+				Secure:   cfg.SecureAuthCookie,
+				MaxAge:   -1,
+			})
+		}
+	}
+
 	// Write wraps writing a response to redirect if the handler
 	// specified it should. This redirect is used for user-facing pages
 	// like workspace applications.
 	write := func(code int, response codersdk.Response) (*database.APIKey, *rbac.Subject, bool) {
+		if code == http.StatusUnauthorized {
+			clearSessionCookie()
+		}
+
 		if cfg.RedirectToLogin {
 			RedirectToLogin(rw, r, nil, response.Message)
 			return nil, nil, false

--- a/coderd/provisionerdserver/acquirer_test.go
+++ b/coderd/provisionerdserver/acquirer_test.go
@@ -548,7 +548,7 @@ func TestAcquirer_MatchTags(t *testing.T) {
 			lines = append(lines, s)
 		}
 		t.Logf("You can paste this into docs/admin/provisioners.md")
-		t.Logf(strings.Join(lines, "\n"))
+		t.Log(strings.Join(lines, "\n"))
 	})
 }
 


### PR DESCRIPTION
Remove old session cookie to properly use new api backend cookies.