### PR TITLE
Display email instead of username on workspace detail page (dev -> main)

### DIFF
--- a/site/src/modules/dashboard/Navbar/UserDropdown/UserDropdownContent.tsx
+++ b/site/src/modules/dashboard/Navbar/UserDropdown/UserDropdownContent.tsx
@@ -70,7 +70,9 @@ export const UserDropdownContent: FC<UserDropdownContentProps> = ({
 	return (
 		<div>
 			<Stack css={styles.info} spacing={0}>
-				<span css={styles.userName}>{user.username}</span>
+				<span css={styles.userName}>
+					{user.email.substring(0, user.email.lastIndexOf("@"))}
+				</span>
 				<span css={styles.userEmail}>{user.email}</span>
 			</Stack>
 

--- a/site/src/pages/WorkspacePage/WorkspaceTopbar.tsx
+++ b/site/src/pages/WorkspacePage/WorkspaceTopbar.tsx
@@ -136,7 +136,7 @@ export const WorkspaceTopbar: FC<WorkspaceProps> = ({
 			<div css={styles.topbarLeft}>
 				<TopbarData>
 					<OwnerBreadcrumb
-						ownerName={workspace.owner_name}
+						ownerName={workspace.owner_email ?? workspace.owner_name}
 						ownerAvatarUrl={workspace.owner_avatar_url}
 					/>
 


### PR DESCRIPTION
## Change
- Display email instead of username on workspace detail page
- Display email prefix instead of username on UserDropDownContent


<img width="339" height="136" alt="image" src="https://github.com/user-attachments/assets/2be98744-7a31-4dcb-a866-5c6de5b3a1fe" />
<br>
<img width="301" height="413" alt="image" src="https://github.com/user-attachments/assets/7b29b95c-de73-4fe5-b53f-e0e060378b75" />
