### PR TITLE
[FEAT] Staging Test - Add workspace migration between templates (API + admin UI)

### DIFF
--- a/coderd/coderd.go
+++ b/coderd/coderd.go
@@ -1035,6 +1035,7 @@ func New(options *Options) *API {
 				r.Get("/", api.template)
 				r.Delete("/", api.deleteTemplate)
 				r.Patch("/", api.patchTemplateMeta)
+				r.Post("/migrate-workspaces", api.postMigrateWorkspacesByTemplate)
 				r.Route("/versions", func(r chi.Router) {
 					r.Post("/archive", api.postArchiveTemplateVersions)
 					r.Get("/", api.templateVersionsByTemplate)

--- a/coderd/database/dbauthz/dbauthz.go
+++ b/coderd/database/dbauthz/dbauthz.go
@@ -4004,6 +4004,13 @@ func (q *querier) UpdateWorkspace(ctx context.Context, arg database.UpdateWorksp
 	return updateWithReturn(q.log, q.auth, fetch, q.db.UpdateWorkspace)(ctx, arg)
 }
 
+func (q *querier) UpdateWorkspaceTemplateID(ctx context.Context, arg database.UpdateWorkspaceTemplateIDParams) (database.WorkspaceTable, error) {
+	if err := q.authorizeContext(ctx, policy.ActionUpdate, rbac.ResourceSystem); err != nil {
+		return database.WorkspaceTable{}, err
+	}
+	return q.db.UpdateWorkspaceTemplateID(ctx, arg)
+}
+
 func (q *querier) UpdateWorkspaceAgentConnectionByID(ctx context.Context, arg database.UpdateWorkspaceAgentConnectionByIDParams) error {
 	if err := q.authorizeContext(ctx, policy.ActionUpdate, rbac.ResourceSystem); err != nil {
 		return err

--- a/coderd/database/dbmem/dbmem.go
+++ b/coderd/database/dbmem/dbmem.go
@@ -10261,6 +10261,27 @@ func (q *FakeQuerier) UpdateWorkspace(_ context.Context, arg database.UpdateWork
 	return database.WorkspaceTable{}, sql.ErrNoRows
 }
 
+func (q *FakeQuerier) UpdateWorkspaceTemplateID(_ context.Context, arg database.UpdateWorkspaceTemplateIDParams) (database.WorkspaceTable, error) {
+	if err := validateDatabaseType(arg); err != nil {
+		return database.WorkspaceTable{}, err
+	}
+
+	q.mutex.Lock()
+	defer q.mutex.Unlock()
+
+	for i, workspace := range q.workspaces {
+		if workspace.Deleted || workspace.ID != arg.ID {
+			continue
+		}
+		workspace.TemplateID = arg.TemplateID
+		workspace.UpdatedAt = arg.UpdatedAt
+		q.workspaces[i] = workspace
+		return workspace, nil
+	}
+
+	return database.WorkspaceTable{}, sql.ErrNoRows
+}
+
 func (q *FakeQuerier) UpdateWorkspaceAgentConnectionByID(_ context.Context, arg database.UpdateWorkspaceAgentConnectionByIDParams) error {
 	if err := validateDatabaseType(arg); err != nil {
 		return err

--- a/coderd/database/dbmetrics/querymetrics.go
+++ b/coderd/database/dbmetrics/querymetrics.go
@@ -2520,6 +2520,13 @@ func (m queryMetricsStore) UpdateWorkspace(ctx context.Context, arg database.Upd
 	return workspace, err
 }
 
+func (m queryMetricsStore) UpdateWorkspaceTemplateID(ctx context.Context, arg database.UpdateWorkspaceTemplateIDParams) (database.WorkspaceTable, error) {
+	start := time.Now()
+	workspace, err := m.s.UpdateWorkspaceTemplateID(ctx, arg)
+	m.queryLatencies.WithLabelValues("UpdateWorkspaceTemplateID").Observe(time.Since(start).Seconds())
+	return workspace, err
+}
+
 func (m queryMetricsStore) UpdateWorkspaceAgentConnectionByID(ctx context.Context, arg database.UpdateWorkspaceAgentConnectionByIDParams) error {
 	start := time.Now()
 	err := m.s.UpdateWorkspaceAgentConnectionByID(ctx, arg)

--- a/coderd/database/dbmock/dbmock.go
+++ b/coderd/database/dbmock/dbmock.go
@@ -5351,6 +5351,21 @@ func (mr *MockStoreMockRecorder) UpdateWorkspace(ctx, arg any) *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateWorkspace", reflect.TypeOf((*MockStore)(nil).UpdateWorkspace), ctx, arg)
 }
 
+// UpdateWorkspaceTemplateID mocks base method.
+func (m *MockStore) UpdateWorkspaceTemplateID(ctx context.Context, arg database.UpdateWorkspaceTemplateIDParams) (database.WorkspaceTable, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "UpdateWorkspaceTemplateID", ctx, arg)
+	ret0, _ := ret[0].(database.WorkspaceTable)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// UpdateWorkspaceTemplateID indicates an expected call of UpdateWorkspaceTemplateID.
+func (mr *MockStoreMockRecorder) UpdateWorkspaceTemplateID(ctx, arg any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateWorkspaceTemplateID", reflect.TypeOf((*MockStore)(nil).UpdateWorkspaceTemplateID), ctx, arg)
+}
+
 // UpdateWorkspaceAgentConnectionByID mocks base method.
 func (m *MockStore) UpdateWorkspaceAgentConnectionByID(ctx context.Context, arg database.UpdateWorkspaceAgentConnectionByIDParams) error {
 	m.ctrl.T.Helper()

--- a/coderd/database/querier.go
+++ b/coderd/database/querier.go
@@ -505,6 +505,7 @@ type sqlcQuerier interface {
 	UpdateUserRoles(ctx context.Context, arg UpdateUserRolesParams) (User, error)
 	UpdateUserStatus(ctx context.Context, arg UpdateUserStatusParams) (User, error)
 	UpdateWorkspace(ctx context.Context, arg UpdateWorkspaceParams) (WorkspaceTable, error)
+	UpdateWorkspaceTemplateID(ctx context.Context, arg UpdateWorkspaceTemplateIDParams) (WorkspaceTable, error)
 	UpdateWorkspaceAgentConnectionByID(ctx context.Context, arg UpdateWorkspaceAgentConnectionByIDParams) error
 	UpdateWorkspaceAgentLifecycleStateByID(ctx context.Context, arg UpdateWorkspaceAgentLifecycleStateByIDParams) error
 	UpdateWorkspaceAgentLogOverflowByID(ctx context.Context, arg UpdateWorkspaceAgentLogOverflowByIDParams) error

--- a/coderd/database/queries.sql.go
+++ b/coderd/database/queries.sql.go
@@ -16686,6 +16686,48 @@ func (q *sqlQuerier) UpdateWorkspace(ctx context.Context, arg UpdateWorkspacePar
 	return i, err
 }
 
+const updateWorkspaceTemplateID = `-- name: UpdateWorkspaceTemplateID :one
+UPDATE
+	workspaces
+SET
+	template_id = $2,
+	updated_at = $3
+WHERE
+	id = $1
+	AND deleted = false
+RETURNING id, created_at, updated_at, owner_id, organization_id, template_id, deleted, name, autostart_schedule, ttl, last_used_at, dormant_at, deleting_at, automatic_updates, favorite, next_start_at
+`
+
+type UpdateWorkspaceTemplateIDParams struct {
+	ID         uuid.UUID `db:"id" json:"id"`
+	TemplateID uuid.UUID `db:"template_id" json:"template_id"`
+	UpdatedAt  time.Time `db:"updated_at" json:"updated_at"`
+}
+
+func (q *sqlQuerier) UpdateWorkspaceTemplateID(ctx context.Context, arg UpdateWorkspaceTemplateIDParams) (WorkspaceTable, error) {
+	row := q.db.QueryRowContext(ctx, updateWorkspaceTemplateID, arg.ID, arg.TemplateID, arg.UpdatedAt)
+	var i WorkspaceTable
+	err := row.Scan(
+		&i.ID,
+		&i.CreatedAt,
+		&i.UpdatedAt,
+		&i.OwnerID,
+		&i.OrganizationID,
+		&i.TemplateID,
+		&i.Deleted,
+		&i.Name,
+		&i.AutostartSchedule,
+		&i.Ttl,
+		&i.LastUsedAt,
+		&i.DormantAt,
+		&i.DeletingAt,
+		&i.AutomaticUpdates,
+		&i.Favorite,
+		&i.NextStartAt,
+	)
+	return i, err
+}
+
 const updateWorkspaceAutomaticUpdates = `-- name: UpdateWorkspaceAutomaticUpdates :exec
 UPDATE
 	workspaces

--- a/coderd/database/queries/workspaces.sql
+++ b/coderd/database/queries/workspaces.sql
@@ -866,3 +866,14 @@ GROUP BY workspaces.id, workspaces.name, latest_build.job_status, latest_build.j
 
 -- name: GetWorkspacesByTemplateID :many
 SELECT * FROM workspaces WHERE template_id = $1 AND deleted = false;
+
+-- name: UpdateWorkspaceTemplateID :one
+UPDATE
+	workspaces
+SET
+	template_id = $2,
+	updated_at = $3
+WHERE
+	id = $1
+	AND deleted = false
+RETURNING *;

--- a/coderd/workspacemigrate.go
+++ b/coderd/workspacemigrate.go
@@ -1,0 +1,179 @@
+package coderd
+
+import (
+	"net/http"
+
+	"github.com/google/uuid"
+
+	"github.com/coder/coder/v2/coderd/database"
+	"github.com/coder/coder/v2/coderd/database/dbauthz"
+	"github.com/coder/coder/v2/coderd/database/dbtime"
+	"github.com/coder/coder/v2/coderd/httpapi"
+	"github.com/coder/coder/v2/coderd/httpmw"
+	"github.com/coder/coder/v2/coderd/rbac/policy"
+	"github.com/coder/coder/v2/codersdk"
+)
+
+// resolveUserEmailsToIDs looks up each email and returns a set of owner IDs.
+// If any email is not found, it writes a 400 response and returns false.
+func (api *API) resolveUserEmailsToIDs(rw http.ResponseWriter, r *http.Request, emails []string) (map[uuid.UUID]struct{}, bool) {
+	ctx := r.Context()
+	ownerIDs := make(map[uuid.UUID]struct{}, len(emails))
+	for _, email := range emails {
+		// nolint:gocritic
+		user, err := api.Database.GetUserByEmailOrUsername(dbauthz.AsSystemRestricted(ctx), database.GetUserByEmailOrUsernameParams{
+			Email: email,
+		})
+		if httpapi.Is404Error(err) {
+			httpapi.Write(ctx, rw, http.StatusBadRequest, codersdk.Response{
+				Message: "User not found.",
+				Detail:  "No user exists with email: " + email,
+			})
+			return nil, false
+		}
+		if err != nil {
+			httpapi.Write(ctx, rw, http.StatusInternalServerError, codersdk.Response{
+				Message: "Failed to fetch user.",
+				Detail:  err.Error(),
+			})
+			return nil, false
+		}
+		ownerIDs[user.ID] = struct{}{}
+	}
+	return ownerIDs, true
+}
+
+// @Summary Migrate workspaces to another template
+// @ID migrate-workspaces-to-template
+// @Security CoderSessionToken
+// @Accept json
+// @Produce json
+// @Tags Templates
+// @Param template path string true "Source Template ID" format(uuid)
+// @Param request body codersdk.MigrateWorkspacesRequest true "Migration request"
+// @Success 200 {object} codersdk.MigrateWorkspacesResponse
+// @Router /templates/{template}/migrate-workspaces [post]
+func (api *API) postMigrateWorkspacesByTemplate(rw http.ResponseWriter, r *http.Request) {
+	ctx := r.Context()
+	sourceTemplate := httpmw.TemplateParam(r)
+
+	// Only template admins (those who can update the template) may migrate workspaces.
+	if !api.Authorize(r, policy.ActionUpdate, sourceTemplate) {
+		httpapi.Forbidden(rw)
+		return
+	}
+
+	var req codersdk.MigrateWorkspacesRequest
+	if !httpapi.Read(ctx, rw, r, &req) {
+		return
+	}
+
+	if req.TargetTemplateID == sourceTemplate.ID {
+		httpapi.Write(ctx, rw, http.StatusBadRequest, codersdk.Response{
+			Message: "Target template must be different from the source template.",
+		})
+		return
+	}
+
+	// Fetch target template using system context to bypass per-template read restrictions.
+	// nolint:gocritic
+	targetTemplate, err := api.Database.GetTemplateByID(dbauthz.AsSystemRestricted(ctx), req.TargetTemplateID)
+	if httpapi.Is404Error(err) {
+		httpapi.Write(ctx, rw, http.StatusBadRequest, codersdk.Response{
+			Message: "Target template not found.",
+		})
+		return
+	}
+	if err != nil {
+		httpapi.Write(ctx, rw, http.StatusInternalServerError, codersdk.Response{
+			Message: "Failed to fetch target template.",
+			Detail:  err.Error(),
+		})
+		return
+	}
+
+	// Caller must also have use permission on the target template.
+	if !api.Authorize(r, policy.ActionUse, targetTemplate) {
+		httpapi.Forbidden(rw)
+		return
+	}
+
+	// Both templates must belong to the same organization.
+	if sourceTemplate.OrganizationID != targetTemplate.OrganizationID {
+		httpapi.Write(ctx, rw, http.StatusBadRequest, codersdk.Response{
+			Message: "Source and target templates must belong to the same organization.",
+		})
+		return
+	}
+
+	// Optionally resolve the requested emails to a set of owner IDs for filtering.
+	var ownerFilter map[uuid.UUID]struct{}
+	if len(req.UserEmails) > 0 {
+		var ok bool
+		ownerFilter, ok = api.resolveUserEmailsToIDs(rw, r, req.UserEmails)
+		if !ok {
+			return
+		}
+	}
+
+	// Fetch all workspaces belonging to the source template.
+	// nolint:gocritic
+	workspaces, err := api.Database.GetWorkspacesByTemplateID(dbauthz.AsSystemRestricted(ctx), sourceTemplate.ID)
+	if err != nil {
+		httpapi.Write(ctx, rw, http.StatusInternalServerError, codersdk.Response{
+			Message: "Failed to fetch workspaces.",
+			Detail:  err.Error(),
+		})
+		return
+	}
+
+	var (
+		migratedIDs []uuid.UUID
+		skippedIDs  []uuid.UUID
+	)
+
+	for _, workspace := range workspaces {
+		// If a user email filter is set, skip workspaces not owned by those users.
+		if ownerFilter != nil {
+			if _, ok := ownerFilter[workspace.OwnerID]; !ok {
+				continue
+			}
+		}
+		// nolint:gocritic
+		latestBuild, err := api.Database.GetLatestWorkspaceBuildByWorkspaceID(dbauthz.AsSystemRestricted(ctx), workspace.ID)
+		if err != nil {
+			httpapi.Write(ctx, rw, http.StatusInternalServerError, codersdk.Response{
+				Message: "Failed to fetch latest workspace build.",
+				Detail:  err.Error(),
+			})
+			return
+		}
+
+		// Skip workspaces that are currently running (last build was a start transition).
+		// These must be stopped before migration.
+		if latestBuild.Transition == database.WorkspaceTransitionStart {
+			skippedIDs = append(skippedIDs, workspace.ID)
+			continue
+		}
+
+		// nolint:gocritic
+		_, err = api.Database.UpdateWorkspaceTemplateID(dbauthz.AsSystemRestricted(ctx), database.UpdateWorkspaceTemplateIDParams{
+			ID:         workspace.ID,
+			TemplateID: targetTemplate.ID,
+			UpdatedAt:  dbtime.Now(),
+		})
+		if err != nil {
+			httpapi.Write(ctx, rw, http.StatusInternalServerError, codersdk.Response{
+				Message: "Failed to migrate workspace.",
+				Detail:  err.Error(),
+			})
+			return
+		}
+		migratedIDs = append(migratedIDs, workspace.ID)
+	}
+
+	httpapi.Write(ctx, rw, http.StatusOK, codersdk.MigrateWorkspacesResponse{
+		MigratedWorkspaceIDs: migratedIDs,
+		SkippedWorkspaceIDs:  skippedIDs,
+	})
+}

--- a/coderd/workspacemigrate_test.go
+++ b/coderd/workspacemigrate_test.go
@@ -1,0 +1,220 @@
+package coderd_test
+
+import (
+	"net/http"
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/require"
+
+	"github.com/coder/coder/v2/coderd/coderdtest"
+	"github.com/coder/coder/v2/coderd/database"
+	"github.com/coder/coder/v2/coderd/rbac"
+	"github.com/coder/coder/v2/codersdk"
+	"github.com/coder/coder/v2/testutil"
+)
+
+func TestPostMigrateWorkspacesByTemplate(t *testing.T) {
+	t.Parallel()
+
+	// setup creates a client with a provisioner daemon, a first user (template admin),
+	// a source template, and a target template in the same organization.
+	setup := func(t *testing.T) (client *codersdk.Client, user codersdk.CreateFirstUserResponse, srcTemplate, dstTemplate codersdk.Template) {
+		t.Helper()
+		client = coderdtest.New(t, &coderdtest.Options{IncludeProvisionerDaemon: true})
+		user = coderdtest.CreateFirstUser(t, client)
+
+		srcVersion := coderdtest.CreateTemplateVersion(t, client, user.OrganizationID, nil)
+		coderdtest.AwaitTemplateVersionJobCompleted(t, client, srcVersion.ID)
+		srcTemplate = coderdtest.CreateTemplate(t, client, user.OrganizationID, srcVersion.ID)
+
+		dstVersion := coderdtest.CreateTemplateVersion(t, client, user.OrganizationID, nil)
+		coderdtest.AwaitTemplateVersionJobCompleted(t, client, dstVersion.ID)
+		dstTemplate = coderdtest.CreateTemplate(t, client, user.OrganizationID, dstVersion.ID)
+
+		return client, user, srcTemplate, dstTemplate
+	}
+
+	t.Run("OK_StoppedWorkspacesMigrated", func(t *testing.T) {
+		t.Parallel()
+
+		client, _, srcTemplate, dstTemplate := setup(t)
+		ctx := testutil.Context(t, testutil.WaitLong)
+
+		// Create a workspace and stop it so it qualifies for migration.
+		workspace := coderdtest.CreateWorkspace(t, client, srcTemplate.ID)
+		coderdtest.AwaitWorkspaceBuildJobCompleted(t, client, workspace.LatestBuild.ID)
+		coderdtest.MustTransitionWorkspace(t, client, workspace.ID, database.WorkspaceTransitionStart, database.WorkspaceTransitionStop)
+
+		resp, err := client.MigrateWorkspaces(ctx, srcTemplate.ID, codersdk.MigrateWorkspacesRequest{
+			TargetTemplateID: dstTemplate.ID,
+		})
+		require.NoError(t, err)
+		require.Contains(t, resp.MigratedWorkspaceIDs, workspace.ID)
+		require.Empty(t, resp.SkippedWorkspaceIDs)
+
+		// Verify the workspace now belongs to the target template.
+		ws, err := client.Workspace(ctx, workspace.ID)
+		require.NoError(t, err)
+		require.Equal(t, dstTemplate.ID, ws.TemplateID)
+	})
+
+	t.Run("SkipsRunningWorkspaces", func(t *testing.T) {
+		t.Parallel()
+
+		client, _, srcTemplate, dstTemplate := setup(t)
+		ctx := testutil.Context(t, testutil.WaitLong)
+
+		// Create a workspace and leave it running (start transition).
+		workspace := coderdtest.CreateWorkspace(t, client, srcTemplate.ID)
+		coderdtest.AwaitWorkspaceBuildJobCompleted(t, client, workspace.LatestBuild.ID)
+
+		resp, err := client.MigrateWorkspaces(ctx, srcTemplate.ID, codersdk.MigrateWorkspacesRequest{
+			TargetTemplateID: dstTemplate.ID,
+		})
+		require.NoError(t, err)
+		require.Contains(t, resp.SkippedWorkspaceIDs, workspace.ID)
+		require.Empty(t, resp.MigratedWorkspaceIDs)
+
+		// Workspace should still belong to the source template.
+		ws, err := client.Workspace(ctx, workspace.ID)
+		require.NoError(t, err)
+		require.Equal(t, srcTemplate.ID, ws.TemplateID)
+	})
+
+	t.Run("MixedStoppedAndRunning", func(t *testing.T) {
+		t.Parallel()
+
+		client, _, srcTemplate, dstTemplate := setup(t)
+		ctx := testutil.Context(t, testutil.WaitLong)
+
+		// Stopped workspace.
+		stopped := coderdtest.CreateWorkspace(t, client, srcTemplate.ID)
+		coderdtest.AwaitWorkspaceBuildJobCompleted(t, client, stopped.LatestBuild.ID)
+		coderdtest.MustTransitionWorkspace(t, client, stopped.ID, database.WorkspaceTransitionStart, database.WorkspaceTransitionStop)
+
+		// Running workspace.
+		running := coderdtest.CreateWorkspace(t, client, srcTemplate.ID)
+		coderdtest.AwaitWorkspaceBuildJobCompleted(t, client, running.LatestBuild.ID)
+
+		resp, err := client.MigrateWorkspaces(ctx, srcTemplate.ID, codersdk.MigrateWorkspacesRequest{
+			TargetTemplateID: dstTemplate.ID,
+		})
+		require.NoError(t, err)
+		require.Contains(t, resp.MigratedWorkspaceIDs, stopped.ID)
+		require.Contains(t, resp.SkippedWorkspaceIDs, running.ID)
+	})
+
+	t.Run("SameTemplateError", func(t *testing.T) {
+		t.Parallel()
+
+		client, _, srcTemplate, _ := setup(t)
+		ctx := testutil.Context(t, testutil.WaitLong)
+
+		_, err := client.MigrateWorkspaces(ctx, srcTemplate.ID, codersdk.MigrateWorkspacesRequest{
+			TargetTemplateID: srcTemplate.ID,
+		})
+		var sdkErr *codersdk.Error
+		require.ErrorAs(t, err, &sdkErr)
+		require.Equal(t, http.StatusBadRequest, sdkErr.StatusCode())
+	})
+
+	t.Run("TargetTemplateNotFound", func(t *testing.T) {
+		t.Parallel()
+
+		client, _, srcTemplate, _ := setup(t)
+		ctx := testutil.Context(t, testutil.WaitLong)
+
+		_, err := client.MigrateWorkspaces(ctx, srcTemplate.ID, codersdk.MigrateWorkspacesRequest{
+			TargetTemplateID: uuid.New(),
+		})
+		var sdkErr *codersdk.Error
+		require.ErrorAs(t, err, &sdkErr)
+		require.Equal(t, http.StatusBadRequest, sdkErr.StatusCode())
+	})
+
+	t.Run("Unauthorized_RegularUser", func(t *testing.T) {
+		t.Parallel()
+
+		client, user, srcTemplate, dstTemplate := setup(t)
+		ctx := testutil.Context(t, testutil.WaitLong)
+
+		// Create a member (non-admin) user.
+		memberClient, _ := coderdtest.CreateAnotherUser(t, client, user.OrganizationID, rbac.RoleMember())
+
+		_, err := memberClient.MigrateWorkspaces(ctx, srcTemplate.ID, codersdk.MigrateWorkspacesRequest{
+			TargetTemplateID: dstTemplate.ID,
+		})
+		var sdkErr *codersdk.Error
+		require.ErrorAs(t, err, &sdkErr)
+		require.Equal(t, http.StatusForbidden, sdkErr.StatusCode())
+	})
+
+	t.Run("UserEmailFilter_OnlyMigratesMatchingOwner", func(t *testing.T) {
+		t.Parallel()
+
+		client, user, srcTemplate, dstTemplate := setup(t)
+		ctx := testutil.Context(t, testutil.WaitLong)
+
+		// Create a second user who will own a workspace.
+		targetClient, targetUser := coderdtest.CreateAnotherUser(t, client, user.OrganizationID)
+
+		// Workspace owned by the target user (stopped → eligible).
+		targetWS := coderdtest.CreateWorkspace(t, targetClient, srcTemplate.ID)
+		coderdtest.AwaitWorkspaceBuildJobCompleted(t, client, targetWS.LatestBuild.ID)
+		coderdtest.MustTransitionWorkspace(t, targetClient, targetWS.ID, database.WorkspaceTransitionStart, database.WorkspaceTransitionStop)
+
+		// Workspace owned by the admin (stopped → eligible but should be excluded by filter).
+		adminWS := coderdtest.CreateWorkspace(t, client, srcTemplate.ID)
+		coderdtest.AwaitWorkspaceBuildJobCompleted(t, client, adminWS.LatestBuild.ID)
+		coderdtest.MustTransitionWorkspace(t, client, adminWS.ID, database.WorkspaceTransitionStart, database.WorkspaceTransitionStop)
+
+		resp, err := client.MigrateWorkspaces(ctx, srcTemplate.ID, codersdk.MigrateWorkspacesRequest{
+			TargetTemplateID: dstTemplate.ID,
+			UserEmails:       []string{targetUser.Email},
+		})
+		require.NoError(t, err)
+		require.Contains(t, resp.MigratedWorkspaceIDs, targetWS.ID)
+		require.NotContains(t, resp.MigratedWorkspaceIDs, adminWS.ID)
+		require.Empty(t, resp.SkippedWorkspaceIDs)
+
+		// targetUser's workspace → migrated.
+		ws, err := client.Workspace(ctx, targetWS.ID)
+		require.NoError(t, err)
+		require.Equal(t, dstTemplate.ID, ws.TemplateID)
+
+		// admin's workspace → untouched.
+		ws, err = client.Workspace(ctx, adminWS.ID)
+		require.NoError(t, err)
+		require.Equal(t, srcTemplate.ID, ws.TemplateID)
+	})
+
+	t.Run("UserEmailFilter_UnknownEmailReturns400", func(t *testing.T) {
+		t.Parallel()
+
+		client, _, srcTemplate, dstTemplate := setup(t)
+		ctx := testutil.Context(t, testutil.WaitLong)
+
+		_, err := client.MigrateWorkspaces(ctx, srcTemplate.ID, codersdk.MigrateWorkspacesRequest{
+			TargetTemplateID: dstTemplate.ID,
+			UserEmails:       []string{"nonexistent@example.com"},
+		})
+		var sdkErr *codersdk.Error
+		require.ErrorAs(t, err, &sdkErr)
+		require.Equal(t, http.StatusBadRequest, sdkErr.StatusCode())
+	})
+
+	t.Run("NoWorkspacesReturnsEmpty", func(t *testing.T) {
+		t.Parallel()
+
+		client, _, srcTemplate, dstTemplate := setup(t)
+		ctx := testutil.Context(t, testutil.WaitLong)
+
+		resp, err := client.MigrateWorkspaces(ctx, srcTemplate.ID, codersdk.MigrateWorkspacesRequest{
+			TargetTemplateID: dstTemplate.ID,
+		})
+		require.NoError(t, err)
+		require.Empty(t, resp.MigratedWorkspaceIDs)
+		require.Empty(t, resp.SkippedWorkspaceIDs)
+	})
+}

--- a/codersdk/workspaces.go
+++ b/codersdk/workspaces.go
@@ -628,6 +628,41 @@ func (c *Client) UnfavoriteWorkspace(ctx context.Context, workspaceID uuid.UUID)
 	return nil
 }
 
+// MigrateWorkspacesRequest is the request body for migrating workspaces
+// from one template to another.
+type MigrateWorkspacesRequest struct {
+	TargetTemplateID uuid.UUID `json:"target_template_id" validate:"required" format:"uuid"`
+	// UserEmails optionally restricts migration to workspaces owned by the
+	// specified users (identified by email). When empty, all workspaces on
+	// the source template are considered.
+	UserEmails []string `json:"user_emails,omitempty"`
+}
+
+// MigrateWorkspacesResponse contains the result of a workspace template migration.
+type MigrateWorkspacesResponse struct {
+	// MigratedWorkspaceIDs lists workspace IDs that were successfully migrated.
+	MigratedWorkspaceIDs []uuid.UUID `json:"migrated_workspace_ids"`
+	// SkippedWorkspaceIDs lists workspace IDs that were skipped because they were running.
+	SkippedWorkspaceIDs []uuid.UUID `json:"skipped_workspace_ids"`
+}
+
+// MigrateWorkspaces migrates all stopped workspaces from the given template
+// to the target template. Running workspaces are skipped and returned in
+// SkippedWorkspaceIDs.
+func (c *Client) MigrateWorkspaces(ctx context.Context, templateID uuid.UUID, req MigrateWorkspacesRequest) (MigrateWorkspacesResponse, error) {
+	path := fmt.Sprintf("/api/v2/templates/%s/migrate-workspaces", templateID)
+	res, err := c.Request(ctx, http.MethodPost, path, req)
+	if err != nil {
+		return MigrateWorkspacesResponse{}, err
+	}
+	defer res.Body.Close()
+	if res.StatusCode != http.StatusOK {
+		return MigrateWorkspacesResponse{}, ReadBodyAsError(res)
+	}
+	var resp MigrateWorkspacesResponse
+	return resp, json.NewDecoder(res.Body).Decode(&resp)
+}
+
 func (c *Client) WorkspaceTimings(ctx context.Context, id uuid.UUID) (WorkspaceBuildTimings, error) {
 	path := fmt.Sprintf("/api/v2/workspaces/%s/timings", id.String())
 	res, err := c.Request(ctx, http.MethodGet, path, nil)

--- a/site/src/api/api.ts
+++ b/site/src/api/api.ts
@@ -1032,6 +1032,17 @@ class ApiMethods {
 		return response.data;
 	};
 
+	migrateWorkspaces = async (
+		templateId: string,
+		data: { target_template_id: string; user_emails?: string[] },
+	): Promise<{ migrated_workspace_ids: string[]; skipped_workspace_ids: string[] }> => {
+		const response = await this.axios.post(
+			`/api/v2/templates/${templateId}/migrate-workspaces`,
+			data,
+		);
+		return response.data;
+	};
+
 	updateTemplateMeta = async (
 		templateId: string,
 		data: TypesGen.UpdateTemplateMeta,

--- a/site/src/api/queries/templates.ts
+++ b/site/src/api/queries/templates.ts
@@ -327,6 +327,24 @@ const waitBuildToBeFinished = async (
 	throw new JobError(data.job, version);
 };
 
+export const migrateWorkspaces = () => {
+	return {
+		mutationFn: ({
+			templateId,
+			targetTemplateId,
+			userEmails,
+		}: {
+			templateId: string;
+			targetTemplateId: string;
+			userEmails?: string[];
+		}) =>
+			API.migrateWorkspaces(templateId, {
+				target_template_id: targetTemplateId,
+				user_emails: userEmails,
+			}),
+	};
+};
+
 export class JobError extends Error {
 	public job: ProvisionerJob;
 	public version: TemplateVersion;

--- a/site/src/pages/TemplateSettingsPage/Sidebar.tsx
+++ b/site/src/pages/TemplateSettingsPage/Sidebar.tsx
@@ -1,5 +1,6 @@
 import VariablesIcon from "@mui/icons-material/CodeOutlined";
 import SecurityIcon from "@mui/icons-material/LockOutlined";
+import MigrateIcon from "@mui/icons-material/MoveDownOutlined";
 import GeneralIcon from "@mui/icons-material/SettingsOutlined";
 import ScheduleIcon from "@mui/icons-material/TimerOutlined";
 import type { Template } from "api/typesGenerated";
@@ -43,6 +44,9 @@ export const Sidebar: FC<SidebarProps> = ({ template }) => {
 			</SidebarNavItem>
 			<SidebarNavItem href="schedule" icon={ScheduleIcon}>
 				Schedule
+			</SidebarNavItem>
+			<SidebarNavItem href="migrate" icon={MigrateIcon}>
+				Migrate Workspaces
 			</SidebarNavItem>
 		</BaseSidebar>
 	);

--- a/site/src/pages/TemplateSettingsPage/TemplateMigratePage/TemplateMigratePage.tsx
+++ b/site/src/pages/TemplateSettingsPage/TemplateMigratePage/TemplateMigratePage.tsx
@@ -1,0 +1,94 @@
+import { API } from "api/api";
+import { getErrorMessage } from "api/errors";
+import { displayError, displaySuccess } from "components/GlobalSnackbar/utils";
+import type { FC } from "react";
+import { useState } from "react";
+import { Helmet } from "react-helmet-async";
+import { useMutation } from "react-query";
+import { pageTitle } from "utils/page";
+import { useTemplateSettings } from "../TemplateSettingsLayout";
+import {
+	type MigrateResult,
+	TemplateMigratePageView,
+} from "./TemplateMigratePageView";
+
+export const TemplateMigratePage: FC = () => {
+	const { template } = useTemplateSettings();
+	const [targetTemplateId, setTargetTemplateId] = useState("");
+	const [userEmailsInput, setUserEmailsInput] = useState("");
+
+	const {
+		mutate: migrate,
+		isLoading: isSubmitting,
+		data: result,
+		error,
+		reset,
+	} = useMutation(
+		async ({
+			targetTemplateId,
+			userEmails,
+		}: {
+			targetTemplateId: string;
+			userEmails?: string[];
+		}): Promise<MigrateResult> => {
+			const raw = await API.migrateWorkspaces(template.id, {
+				target_template_id: targetTemplateId,
+				user_emails: userEmails,
+			});
+
+			const fetchAll = (ids: string[]) =>
+				Promise.all(ids.map((id) => API.getWorkspace(id)));
+
+			const [migrated, skipped] = await Promise.all([
+				fetchAll(raw.migrated_workspace_ids),
+				fetchAll(raw.skipped_workspace_ids),
+			]);
+
+			return { migrated, skipped };
+		},
+		{
+			onSuccess: (data) => {
+				displaySuccess(
+					`Migrated ${data.migrated.length} workspace(s) successfully.`,
+				);
+			},
+			onError: (err) => {
+				displayError(getErrorMessage(err, "Failed to migrate workspaces"));
+			},
+		},
+	);
+
+	const handleSubmit = () => {
+		reset();
+		const userEmails = userEmailsInput
+			.split(",")
+			.map((e) => e.trim())
+			.filter(Boolean);
+
+		migrate({
+			targetTemplateId: targetTemplateId.trim(),
+			userEmails: userEmails.length > 0 ? userEmails : undefined,
+		});
+	};
+
+	return (
+		<>
+			<Helmet>
+				<title>{pageTitle(template.name, "Migrate Workspaces")}</title>
+			</Helmet>
+			<TemplateMigratePageView
+				templateName={template.display_name || template.name}
+				targetTemplateId={targetTemplateId}
+				onTargetTemplateIdChange={setTargetTemplateId}
+				userEmailsInput={userEmailsInput}
+				onUserEmailsInputChange={setUserEmailsInput}
+				isSubmitting={isSubmitting}
+				result={result}
+				error={error}
+				onSubmit={handleSubmit}
+			/>
+		</>
+	);
+};
+
+export default TemplateMigratePage;

--- a/site/src/pages/TemplateSettingsPage/TemplateMigratePage/TemplateMigratePageView.tsx
+++ b/site/src/pages/TemplateSettingsPage/TemplateMigratePage/TemplateMigratePageView.tsx
@@ -1,0 +1,157 @@
+import Button from "@mui/material/Button";
+import Table from "@mui/material/Table";
+import TableBody from "@mui/material/TableBody";
+import TableCell from "@mui/material/TableCell";
+import TableHead from "@mui/material/TableHead";
+import TableRow from "@mui/material/TableRow";
+import TextField from "@mui/material/TextField";
+import type { Workspace } from "api/typesGenerated";
+import { Alert } from "components/Alert/Alert";
+import { PageHeader, PageHeaderTitle } from "components/PageHeader/PageHeader";
+import type { FC } from "react";
+
+export interface MigrateResult {
+	migrated: Workspace[];
+	skipped: Workspace[];
+}
+
+interface TemplateMigratePageViewProps {
+	templateName: string;
+	targetTemplateId: string;
+	onTargetTemplateIdChange: (value: string) => void;
+	userEmailsInput: string;
+	onUserEmailsInputChange: (value: string) => void;
+	isSubmitting: boolean;
+	result: MigrateResult | undefined;
+	error: unknown;
+	onSubmit: () => void;
+}
+
+const WorkspaceTable: FC<{ workspaces: Workspace[]; emptyText: string }> = ({
+	workspaces,
+	emptyText,
+}) => {
+	if (workspaces.length === 0) {
+		return (
+			<p className="text-sm text-content-secondary italic">{emptyText}</p>
+		);
+	}
+
+	return (
+		<Table size="small">
+			<TableHead>
+				<TableRow>
+					<TableCell>Workspace</TableCell>
+					<TableCell>Owner</TableCell>
+					<TableCell>Email</TableCell>
+				</TableRow>
+			</TableHead>
+			<TableBody>
+				{workspaces.map((ws) => (
+					<TableRow key={ws.id}>
+						<TableCell className="font-mono text-xs">{ws.name}</TableCell>
+						<TableCell>{ws.owner_name}</TableCell>
+						<TableCell>{ws.owner_email}</TableCell>
+					</TableRow>
+				))}
+			</TableBody>
+		</Table>
+	);
+};
+
+export const TemplateMigratePageView: FC<TemplateMigratePageViewProps> = ({
+	templateName,
+	targetTemplateId,
+	onTargetTemplateIdChange,
+	userEmailsInput,
+	onUserEmailsInputChange,
+	isSubmitting,
+	result,
+	error,
+	onSubmit,
+}) => {
+	return (
+		<div>
+			<PageHeader css={{ paddingTop: 0 }}>
+				<PageHeaderTitle>Migrate Workspaces</PageHeaderTitle>
+			</PageHeader>
+
+			<p className="text-sm text-content-secondary mb-6">
+				Move all stopped workspaces from{" "}
+				<strong className="text-content-primary">{templateName}</strong> to
+				another template. Running workspaces will be skipped.
+			</p>
+
+			<div className="flex flex-col gap-4 max-w-lg">
+				<TextField
+					label="Target Template ID"
+					placeholder="xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx"
+					value={targetTemplateId}
+					onChange={(e) => onTargetTemplateIdChange(e.target.value)}
+					size="small"
+					fullWidth
+					required
+					helperText="The UUID of the template to migrate workspaces into."
+				/>
+
+				<TextField
+					label="User Emails (optional)"
+					placeholder="alice@example.com, bob@example.com"
+					value={userEmailsInput}
+					onChange={(e) => onUserEmailsInputChange(e.target.value)}
+					size="small"
+					fullWidth
+					multiline
+					rows={3}
+					helperText="Comma-separated list of user emails. Leave empty to migrate all users' workspaces."
+				/>
+
+				{error != null && (
+					<Alert severity="error">
+						{error instanceof Error ? error.message : String(error)}
+					</Alert>
+				)}
+
+				<div>
+					<Button
+						variant="contained"
+						color="primary"
+						disabled={isSubmitting || targetTemplateId.trim() === ""}
+						onClick={onSubmit}
+					>
+						{isSubmitting ? "Migrating…" : "Migrate Workspaces"}
+					</Button>
+				</div>
+			</div>
+
+			{result != null && (
+				<div className="mt-8 flex flex-col gap-6">
+					<section>
+						<h2 className="text-sm font-semibold text-content-primary mb-2">
+							Migrated ({result.migrated.length})
+						</h2>
+						<WorkspaceTable
+							workspaces={result.migrated}
+							emptyText="No workspaces were migrated."
+						/>
+					</section>
+
+					<section>
+						<h2 className="text-sm font-semibold text-content-secondary mb-2">
+							Skipped — still running ({result.skipped.length})
+						</h2>
+						<WorkspaceTable
+							workspaces={result.skipped}
+							emptyText="No workspaces were skipped."
+						/>
+						{result.skipped.length > 0 && (
+							<p className="mt-2 text-xs text-content-secondary">
+								Stop these workspaces and run migration again to include them.
+							</p>
+						)}
+					</section>
+				</div>
+			)}
+		</div>
+	);
+};

--- a/site/src/router.tsx
+++ b/site/src/router.tsx
@@ -218,6 +218,12 @@ const TemplateSchedulePage = lazy(
 			"./pages/TemplateSettingsPage/TemplateSchedulePage/TemplateSchedulePage"
 		),
 );
+const TemplateMigratePage = lazy(
+	() =>
+		import(
+			"./pages/TemplateSettingsPage/TemplateMigratePage/TemplateMigratePage"
+		),
+);
 const TemplateSettingsPage = lazy(
 	() =>
 		import(
@@ -341,6 +347,7 @@ const templateRouter = () => {
 					<Route path="permissions" element={<TemplatePermissionsPage />} />
 					<Route path="variables" element={<TemplateVariablesPage />} />
 					<Route path="schedule" element={<TemplateSchedulePage />} />
+					<Route path="migrate" element={<TemplateMigratePage />} />
 				</Route>
 
 				<Route path="versions">


### PR DESCRIPTION
## Summary
                                                                                                                                            
  Adds end-to-end support for migrating stopped workspaces from one template to another, including a new REST endpoint, Go tests, and an admin settings page.
                                                                                                                                            
  ### Backend (`coderd/`)
                                                                                                                                            
  - Add `POST /api/v2/templates/{template}/migrate-workspaces` endpoint                                                                     
    - Requires `update` permission on source template and `use` permission on target template
    - Source and target templates must belong to the same organization                                                                      
    - Running workspaces are skipped and returned in `skipped_workspace_ids`                                                                
    - Optional `user_emails` field restricts migration to workspaces owned by specific users                                                
  - Add `GetWorkspacesByTemplateID` and `UpdateWorkspaceTemplateID` DB queries                                                              
  - Add `resolveUserEmailsToIDs` helper to resolve email list → owner ID set                                                                
                                                                                                                                            
  ### Frontend (`site/`)                                                                                                                    
                                                                                                                                            
  - Add `API.migrateWorkspaces()` client method                                                                                             
  - Add `migrateWorkspaces` mutation in `api/queries/templates.ts`
  - Add **Migrate Workspaces** page at `/templates/:template/settings/migrate`                                                              
    - Target Template ID input (required)                                                                                                   
    - User Emails input (optional, comma-separated)                                                                                         
    - After migration: results table showing workspace name, owner name, and owner email for both migrated and skipped workspaces           
  - Register lazy-loaded route and sidebar nav item under template settings