### PR TITLE
fix: hide blocked workspace template from create menu

### DIFF
--- a/site/src/pages/WorkspacesPage/WorkspacesButton.test.tsx
+++ b/site/src/pages/WorkspacesPage/WorkspacesButton.test.tsx
@@ -19,22 +19,22 @@ describe("WorkspacesButton", () => {
 		jest.useRealTimers();
 	});
 
-	it("hides the blocked template name from the new workspace menu", async () => {
+	it("hides the blocked template display name from the new workspace menu", async () => {
 		jest.useFakeTimers();
 		const user = userEvent.setup({ advanceTimers: jest.advanceTimersByTime });
 		const blockedTemplate: Template = {
 			...MockTemplate,
 			id: "heaan2-011-a100",
-			name: "HEAAN2-0.1.1-playground-a100",
-			display_name: "Blocked A100 template",
-			active_user_count: 119,
+			name: "heaan2-011-a100",
+			display_name: "HEAAN2-0.1.1 Playground (A100)",
+			active_user_count: 120,
 		};
 		const enabledTemplate: Template = {
 			...MockTemplate,
-			id: "heaan2-current-a100",
-			name: "heaan2-current-playground-a100",
-			display_name: "HEAAN2-0.1.1 Playground (A100)",
-			active_user_count: 42,
+			id: "heaan2-020-a100",
+			name: "heaan2-020-a100",
+			display_name: "HEaaN2-0.2.0 Playground (A100)",
+			active_user_count: 101,
 		};
 
 		renderWorkspacesButton(
@@ -53,13 +53,12 @@ describe("WorkspacesButton", () => {
 			jest.runOnlyPendingTimers();
 		});
 
-		expect(screen.queryByText("Blocked A100 template")).not.toBeInTheDocument();
 		expect(
-			screen.getByText("HEAAN2-0.1.1 Playground (A100)").closest("a"),
-		).toHaveAttribute(
-			"href",
-			"/templates/heaan2-current-playground-a100/workspace",
-		);
+			screen.queryByText("HEAAN2-0.1.1 Playground (A100)"),
+		).not.toBeInTheDocument();
+		expect(
+			screen.getByText("HEaaN2-0.2.0 Playground (A100)").closest("a"),
+		).toHaveAttribute("href", "/templates/heaan2-020-a100/workspace");
 	});
 });
 

--- a/site/src/pages/WorkspacesPage/WorkspacesButton.test.tsx
+++ b/site/src/pages/WorkspacesPage/WorkspacesButton.test.tsx
@@ -1,0 +1,86 @@
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import type { Template } from "api/typesGenerated";
+import { ThemeProvider } from "contexts/ThemeProvider";
+import { DashboardContext } from "modules/dashboard/DashboardProvider";
+import { act } from "react";
+import { RouterProvider, createMemoryRouter } from "react-router-dom";
+import {
+	MockAppearanceConfig,
+	MockDefaultOrganization,
+	MockEntitlements,
+	MockExperiments,
+	MockTemplate,
+} from "testHelpers/entities";
+import { WorkspacesButton } from "./WorkspacesButton";
+
+describe("WorkspacesButton", () => {
+	afterEach(() => {
+		jest.useRealTimers();
+	});
+
+	it("hides the blocked template name from the new workspace menu", async () => {
+		jest.useFakeTimers();
+		const user = userEvent.setup({ advanceTimers: jest.advanceTimersByTime });
+		const blockedTemplate: Template = {
+			...MockTemplate,
+			id: "heaan2-011-a100",
+			name: "HEAAN2-0.1.1-playground-a100",
+			display_name: "Blocked A100 template",
+			active_user_count: 119,
+		};
+		const enabledTemplate: Template = {
+			...MockTemplate,
+			id: "heaan2-current-a100",
+			name: "heaan2-current-playground-a100",
+			display_name: "HEAAN2-0.1.1 Playground (A100)",
+			active_user_count: 42,
+		};
+
+		renderWorkspacesButton(
+			<WorkspacesButton
+				templates={[blockedTemplate, enabledTemplate]}
+				templatesFetchStatus="success"
+			>
+				New workspace
+			</WorkspacesButton>,
+		);
+
+		await act(async () => {
+			await user.click(screen.getByRole("button", { name: /new workspace/i }));
+		});
+		await act(async () => {
+			jest.runOnlyPendingTimers();
+		});
+
+		expect(screen.queryByText("Blocked A100 template")).not.toBeInTheDocument();
+		expect(
+			screen.getByText("HEAAN2-0.1.1 Playground (A100)").closest("a"),
+		).toHaveAttribute(
+			"href",
+			"/templates/heaan2-current-playground-a100/workspace",
+		);
+	});
+});
+
+function renderWorkspacesButton(element: JSX.Element) {
+	render(
+		<ThemeProvider>
+			<DashboardContext.Provider
+				value={{
+					entitlements: MockEntitlements,
+					experiments: MockExperiments,
+					appearance: MockAppearanceConfig,
+					organizations: [MockDefaultOrganization],
+					showOrganizations: false,
+				}}
+			>
+				<RouterProvider
+					router={createMemoryRouter([{ path: "/", element }], {
+						initialEntries: ["/"],
+					})}
+				/>
+			</DashboardContext.Provider>
+		</ThemeProvider>,
+	);
+}

--- a/site/src/pages/WorkspacesPage/WorkspacesButton.tsx
+++ b/site/src/pages/WorkspacesPage/WorkspacesButton.tsx
@@ -37,7 +37,13 @@ export const WorkspacesButton: FC<WorkspacesButtonProps> = ({
 	// Dataset should always be small enough that client-side filtering should be
 	// good enough. Can swap out down the line if it becomes an issue
 	const [searchTerm, setSearchTerm] = useState("");
-	const processed = sortTemplatesByUsersDesc(templates ?? [], searchTerm);
+	const processed = sortTemplatesByUsersDesc(
+		(templates ?? []).filter(
+			(template) =>
+				template.name.toLowerCase() !== "heaan2-0.1.1-playground-a100",
+		),
+		searchTerm,
+	);
 
 	let emptyState: ReactNode = undefined;
 	if (templates?.length === 0) {

--- a/site/src/pages/WorkspacesPage/WorkspacesButton.tsx
+++ b/site/src/pages/WorkspacesPage/WorkspacesButton.tsx
@@ -40,7 +40,8 @@ export const WorkspacesButton: FC<WorkspacesButtonProps> = ({
 	const processed = sortTemplatesByUsersDesc(
 		(templates ?? []).filter(
 			(template) =>
-				template.name.toLowerCase() !== "heaan2-0.1.1-playground-a100",
+				(template.display_name || template.name).toLowerCase() !==
+				"heaan2-0.1.1 playground (a100)",
 		),
 		searchTerm,
 	);

--- a/site/src/testHelpers/entities.ts
+++ b/site/src/testHelpers/entities.ts
@@ -1331,6 +1331,7 @@ export const MockWorkspace: TypesGen.Workspace = {
 	organization_id: MockOrganization.id,
 	organization_name: "default",
 	owner_name: MockUser.username,
+	owner_email: MockUser.email,
 	owner_avatar_url: "https://avatars.githubusercontent.com/u/7122116?v=4",
 	autostart_schedule: MockWorkspaceAutostartEnabled.schedule,
 	ttl_ms: 2 * 60 * 60 * 1000,


### PR DESCRIPTION
## Context
HEAAN2 0.1.1 A100 template should not be available when users create a new workspace. Existing workspaces created from that template should remain visible and unaffected.

## Solution
- Filter the blocked template out of the New workspace template menu
- Match the blocked template name case-insensitively
- Keep the existing workspace list/detail behavior unchanged
- Add a focused WorkspacesButton test for the hidden template behavior
- Add owner_email to the MockWorkspace fixture so site type checking passes

## Notes
- Created so the change can be checked in the development environment.
- Verified locally with:
  - pnpm -C site exec jest --selectProjects test --runTestsByPath src/pages/WorkspacesPage/WorkspacesButton.test.tsx --runInBand
  - pnpm -C site exec biome check src/pages/WorkspacesPage/WorkspacesButton.tsx src/pages/WorkspacesPage/WorkspacesButton.test.tsx src/testHelpers/entities.ts
  - pnpm -C site lint:types
  - git diff --check