### PR TITLE
fix: hide blocked template access for non-admins

### DIFF
--- a/site/src/pages/TemplatePage/TemplateRedirectController.test.tsx
+++ b/site/src/pages/TemplatePage/TemplateRedirectController.test.tsx
@@ -1,14 +1,70 @@
-import { waitFor } from "@testing-library/react";
-import { API } from "api/api";
+import { render, waitFor } from "@testing-library/react";
+import { AuthContext } from "contexts/auth/AuthProvider";
+import type { Permissions } from "contexts/auth/permissions";
+import { DashboardContext } from "modules/dashboard/DashboardProvider";
+import { RouterProvider, createMemoryRouter } from "react-router-dom";
 import * as M from "testHelpers/entities";
-import { renderWithAuth } from "testHelpers/renderHelpers";
 import { TemplateRedirectController } from "./TemplateRedirectController";
 
-const renderTemplateRedirectController = (route: string) => {
-	return renderWithAuth(<TemplateRedirectController />, {
-		route,
-		path: "/templates/:organization?/:template",
-	});
+const renderTemplateRedirectController = (
+	route: string,
+	options: {
+		permissionOverrides?: Partial<Permissions>;
+		showOrganizations?: boolean;
+		organizations?: (typeof M.MockDefaultOrganization)[];
+	} = {},
+) => {
+	const router = createMemoryRouter(
+		[
+			{
+				path: "/templates/:organization?/:template",
+				element: <TemplateRedirectController />,
+			},
+			{
+				path: "/templates",
+				element: <div />,
+			},
+		],
+		{ initialEntries: [route] },
+	);
+
+	render(
+		<AuthContext.Provider
+			value={{
+				isLoading: false,
+				isSignedOut: false,
+				isSigningOut: false,
+				isConfiguringTheFirstUser: false,
+				isSignedIn: true,
+				isSigningIn: false,
+				isUpdatingProfile: false,
+				user: M.MockUser,
+				permissions: {
+					...M.MockPermissions,
+					...options.permissionOverrides,
+				},
+				signInError: undefined,
+				updateProfileError: undefined,
+				signOut: jest.fn(),
+				signIn: jest.fn(),
+				updateProfile: jest.fn(),
+			}}
+		>
+			<DashboardContext.Provider
+				value={{
+					entitlements: M.MockEntitlements,
+					experiments: M.MockExperiments,
+					appearance: M.MockAppearanceConfig,
+					organizations: options.organizations ?? [M.MockDefaultOrganization],
+					showOrganizations: options.showOrganizations ?? false,
+				}}
+			>
+				<RouterProvider router={router} />
+			</DashboardContext.Provider>
+		</AuthContext.Provider>,
+	);
+
+	return { router };
 };
 
 it("redirects from multi-org to single-org", async () => {
@@ -24,12 +80,12 @@ it("redirects from multi-org to single-org", async () => {
 });
 
 it("redirects from single-org to multi-org", async () => {
-	jest
-		.spyOn(API, "getOrganizations")
-		.mockResolvedValueOnce([M.MockDefaultOrganization, M.MockOrganization2]);
-
 	const { router } = renderTemplateRedirectController(
 		`/templates/${M.MockTemplate.name}`,
+		{
+			organizations: [M.MockDefaultOrganization, M.MockOrganization2],
+			showOrganizations: true,
+		},
 	);
 
 	await waitFor(() =>
@@ -38,3 +94,27 @@ it("redirects from single-org to multi-org", async () => {
 		),
 	);
 });
+
+it.each(["/templates/heaan-playground", "/templates/heaan2-playground-011"])(
+	"redirects non-admins from blocked template URL %s",
+	async (route) => {
+		const { router } = renderTemplateRedirectController(route, {
+			permissionOverrides: { deleteTemplates: false },
+		});
+
+		await waitFor(() =>
+			expect(router.state.location.pathname).toBe("/templates"),
+		);
+	},
+);
+
+it.each(["/templates/heaan-playground", "/templates/heaan2-playground-011"])(
+	"allows admins to open blocked template URL %s",
+	async (route) => {
+		const { router } = renderTemplateRedirectController(route, {
+			permissionOverrides: { deleteTemplates: true },
+		});
+
+		await waitFor(() => expect(router.state.location.pathname).toBe(route));
+	},
+);

--- a/site/src/pages/TemplatePage/TemplateRedirectController.tsx
+++ b/site/src/pages/TemplatePage/TemplateRedirectController.tsx
@@ -1,15 +1,27 @@
 import type { Organization } from "api/typesGenerated";
+import { useAuthContext } from "contexts/auth/AuthProvider";
 import { useDashboard } from "modules/dashboard/useDashboard";
 import type { FC } from "react";
 import { Navigate, Outlet, useLocation, useParams } from "react-router-dom";
+import { isBlockedTemplateRouteName } from "utils/templates";
 
 export const TemplateRedirectController: FC = () => {
 	const { organizations, showOrganizations } = useDashboard();
+	const { permissions } = useAuthContext();
 	const { organization, template } = useParams() as {
 		organization?: string;
 		template: string;
 	};
 	const location = useLocation();
+
+	if (
+		!permissions?.deleteTemplates &&
+		!organization &&
+		isBlockedTemplateRouteName(template) &&
+		location.pathname === `/templates/${template}`
+	) {
+		return <Navigate to="/templates" replace />;
+	}
 
 	// We redirect templates without an organization to the default organization,
 	// as that's likely what any links floating around expect.

--- a/site/src/pages/TemplatesPage/TemplatesPage.test.tsx
+++ b/site/src/pages/TemplatesPage/TemplatesPage.test.tsx
@@ -1,42 +1,155 @@
 import { render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
-import { AppProviders } from "App";
-import { RequireAuth } from "contexts/auth/RequireAuth";
+import type { Template } from "api/typesGenerated";
+import type { UseFilterResult } from "components/Filter/Filter";
+import { ThemeProvider } from "contexts/ThemeProvider";
+import { DashboardContext } from "modules/dashboard/DashboardProvider";
+import { act } from "react";
+import { HelmetProvider } from "react-helmet-async";
+import { QueryClient, QueryClientProvider } from "react-query";
 import { RouterProvider, createMemoryRouter } from "react-router-dom";
-import TemplatesPage from "./TemplatesPage";
+import {
+	MockAppearanceConfig,
+	MockDefaultOrganization,
+	MockEntitlements,
+	MockExperiments,
+	MockTemplate,
+} from "testHelpers/entities";
+import { TemplatesPageView } from "./TemplatesPageView";
 
 test("create template from scratch", async () => {
 	const user = userEvent.setup();
-	const router = createMemoryRouter(
-		[
+	const router = renderTemplatesPage({
+		extraRoutes: [
 			{
-				element: <RequireAuth />,
-				children: [
-					{
-						path: "/templates",
-						element: <TemplatesPage />,
-					},
-					{
-						path: "/templates/new",
-						element: <div data-testid="new-template-page" />,
-					},
-				],
+				path: "/templates/new",
+				element: <div data-testid="new-template-page" />,
 			},
 		],
-		{ initialEntries: ["/templates"] },
-	);
-	render(
-		<AppProviders>
-			<RouterProvider router={router} />
-		</AppProviders>,
-	);
+	});
+
 	const createTemplateButton = await screen.findByRole("button", {
 		name: "Create Template",
 	});
-	await user.click(createTemplateButton);
+	await act(async () => {
+		await user.click(createTemplateButton);
+	});
 	const fromScratchMenuItem = await screen.findByText("From scratch");
-	await user.click(fromScratchMenuItem);
+	await act(async () => {
+		await user.click(fromScratchMenuItem);
+	});
+
 	await screen.findByTestId("new-template-page");
 	expect(router.state.location.pathname).toBe("/templates/new");
 	expect(router.state.location.search).toBe("?exampleId=scratch");
 });
+
+test("hides the blocked template from non-admin users", async () => {
+	renderTemplatesPage({
+		templates: heaanTemplates,
+		hideBlockedTemplates: true,
+	});
+
+	await screen.findByText("Visible Template");
+	expect(
+		screen.queryByText("HEAAN2-0.1.1 Playground (A100)"),
+	).not.toBeInTheDocument();
+});
+
+test("shows the blocked template to admins", async () => {
+	renderTemplatesPage({
+		templates: heaanTemplates,
+		hideBlockedTemplates: false,
+	});
+
+	await screen.findByText("Visible Template");
+	expect(
+		await screen.findByText("HEAAN2-0.1.1 Playground (A100)"),
+	).toBeInTheDocument();
+});
+
+const heaanTemplates = [
+	{
+		...MockTemplate,
+		id: "blocked-heaan2-011",
+		name: "heaan2-011-a100",
+		display_name: "HEAAN2-0.1.1 Playground (A100)",
+	},
+	{
+		...MockTemplate,
+		id: "visible-heaan2-020",
+		name: "heaan2-020-a100",
+		display_name: "Visible Template",
+	},
+];
+
+const renderTemplatesPage = ({
+	templates = [MockTemplate],
+	hideBlockedTemplates = false,
+	extraRoutes = [],
+}: {
+	templates?: Template[];
+	hideBlockedTemplates?: boolean;
+	extraRoutes?: Parameters<typeof createMemoryRouter>[0];
+} = {}) => {
+	const router = createMemoryRouter(
+		[
+			{
+				path: "/templates",
+				element: (
+					<TemplatesPageView
+						error={undefined}
+						filter={mockFilter}
+						showOrganizations={false}
+						canCreateTemplates={true}
+						examples={[]}
+						templates={templates}
+						hideBlockedTemplates={hideBlockedTemplates}
+					/>
+				),
+			},
+			...extraRoutes,
+		],
+		{ initialEntries: ["/templates"] },
+	);
+	const queryClient = new QueryClient({
+		defaultOptions: {
+			queries: {
+				retry: false,
+				cacheTime: 0,
+				refetchOnWindowFocus: false,
+			},
+		},
+	});
+
+	render(
+		<HelmetProvider>
+			<QueryClientProvider client={queryClient}>
+				<ThemeProvider>
+					<DashboardContext.Provider
+						value={{
+							entitlements: MockEntitlements,
+							experiments: MockExperiments,
+							appearance: MockAppearanceConfig,
+							organizations: [MockDefaultOrganization],
+							showOrganizations: false,
+						}}
+					>
+						<RouterProvider router={router} />
+					</DashboardContext.Provider>
+				</ThemeProvider>
+			</QueryClientProvider>
+		</HelmetProvider>,
+	);
+
+	return router;
+};
+
+const mockFilter = {
+	query: "deprecated:false",
+	values: { deprecated: "false" },
+	update: jest.fn(),
+	debounceUpdate: jest.fn(),
+	cancelDebounce: jest.fn(),
+	used: false,
+} satisfies UseFilterResult;

--- a/site/src/pages/TemplatesPage/TemplatesPage.tsx
+++ b/site/src/pages/TemplatesPage/TemplatesPage.tsx
@@ -39,6 +39,7 @@ export const TemplatesPage: FC = () => {
 				canCreateTemplates={permissions.createTemplates}
 				examples={examplesQuery.data}
 				templates={templatesQuery.data}
+				hideBlockedTemplates={!permissions.deleteTemplates}
 			/>
 		</>
 	);

--- a/site/src/pages/TemplatesPage/TemplatesPageView.tsx
+++ b/site/src/pages/TemplatesPage/TemplatesPageView.tsx
@@ -45,6 +45,7 @@ import { Link, useNavigate } from "react-router-dom";
 import { createDayString } from "utils/createDayString";
 import { docs } from "utils/docs";
 import {
+	filterBlockedWorkspaceTemplates,
 	formatTemplateActiveDevelopers,
 	formatTemplateBuildTime,
 } from "utils/templates";
@@ -181,6 +182,7 @@ export interface TemplatesPageViewProps {
 	canCreateTemplates: boolean;
 	examples: TemplateExample[] | undefined;
 	templates: Template[] | undefined;
+	hideBlockedTemplates?: boolean;
 }
 
 export const TemplatesPageView: FC<TemplatesPageViewProps> = ({
@@ -190,9 +192,14 @@ export const TemplatesPageView: FC<TemplatesPageViewProps> = ({
 	canCreateTemplates,
 	examples,
 	templates,
+	hideBlockedTemplates = true,
 }) => {
-	const isLoading = !templates;
-	const isEmpty = templates && templates.length === 0;
+	const visibleTemplates = filterBlockedWorkspaceTemplates(
+		templates,
+		hideBlockedTemplates,
+	);
+	const isLoading = !visibleTemplates;
+	const isEmpty = visibleTemplates && visibleTemplates.length === 0;
 	const navigate = useNavigate();
 
 	const createTemplateAction = showOrganizations ? (
@@ -248,7 +255,7 @@ export const TemplatesPageView: FC<TemplatesPageViewProps> = ({
 								examples={examples ?? []}
 							/>
 						) : (
-							templates?.map((template) => (
+							visibleTemplates?.map((template) => (
 								<TemplateRow
 									key={template.id}
 									showOrganizations={showOrganizations}

--- a/site/src/pages/WorkspacesPage/WorkspacesButton.test.tsx
+++ b/site/src/pages/WorkspacesPage/WorkspacesButton.test.tsx
@@ -60,6 +60,39 @@ describe("WorkspacesButton", () => {
 			screen.getByText("HEaaN2-0.2.0 Playground (A100)").closest("a"),
 		).toHaveAttribute("href", "/templates/heaan2-020-a100/workspace");
 	});
+
+	it("shows the blocked template when blocked template filtering is disabled", async () => {
+		jest.useFakeTimers();
+		const user = userEvent.setup({ advanceTimers: jest.advanceTimersByTime });
+		const blockedTemplate: Template = {
+			...MockTemplate,
+			id: "heaan2-011-a100",
+			name: "heaan2-011-a100",
+			display_name: "HEAAN2-0.1.1 Playground (A100)",
+			active_user_count: 120,
+		};
+
+		renderWorkspacesButton(
+			<WorkspacesButton
+				templates={[blockedTemplate]}
+				templatesFetchStatus="success"
+				hideBlockedTemplates={false}
+			>
+				New workspace
+			</WorkspacesButton>,
+		);
+
+		await act(async () => {
+			await user.click(screen.getByRole("button", { name: /new workspace/i }));
+		});
+		await act(async () => {
+			jest.runOnlyPendingTimers();
+		});
+
+		expect(
+			screen.getByText("HEAAN2-0.1.1 Playground (A100)").closest("a"),
+		).toHaveAttribute("href", "/templates/heaan2-011-a100/workspace");
+	});
 });
 
 function renderWorkspacesButton(element: JSX.Element) {

--- a/site/src/pages/WorkspacesPage/WorkspacesButton.tsx
+++ b/site/src/pages/WorkspacesPage/WorkspacesButton.tsx
@@ -20,6 +20,7 @@ import {
 	Link as RouterLink,
 	type LinkProps as RouterLinkProps,
 } from "react-router-dom";
+import { filterBlockedWorkspaceTemplates } from "utils/templates";
 
 type TemplatesQuery = UseQueryResult<Template[]>;
 
@@ -27,22 +28,21 @@ interface WorkspacesButtonProps {
 	children?: ReactNode;
 	templatesFetchStatus: TemplatesQuery["status"];
 	templates: TemplatesQuery["data"];
+	hideBlockedTemplates?: boolean;
 }
 
 export const WorkspacesButton: FC<WorkspacesButtonProps> = ({
 	children,
 	templatesFetchStatus,
 	templates,
+	hideBlockedTemplates = true,
 }) => {
 	// Dataset should always be small enough that client-side filtering should be
 	// good enough. Can swap out down the line if it becomes an issue
 	const [searchTerm, setSearchTerm] = useState("");
 	const processed = sortTemplatesByUsersDesc(
-		(templates ?? []).filter(
-			(template) =>
-				(template.display_name || template.name).toLowerCase() !==
-				"heaan2-0.1.1 playground (a100)",
-		),
+		filterBlockedWorkspaceTemplates(templates ?? [], hideBlockedTemplates) ??
+			[],
 		searchTerm,
 	);
 

--- a/site/src/pages/WorkspacesPage/WorkspacesPage.tsx
+++ b/site/src/pages/WorkspacesPage/WorkspacesPage.tsx
@@ -94,6 +94,7 @@ const WorkspacesPage: FC = () => {
 				templatesFetchStatus={templatesQuery.status}
 				workspaces={data?.workspaces}
 				error={error}
+				hideBlockedTemplates={!permissions.deleteTemplates}
 				count={data?.count}
 				page={pagination.page}
 				limit={pagination.limit}

--- a/site/src/pages/WorkspacesPage/WorkspacesPageView.tsx
+++ b/site/src/pages/WorkspacesPage/WorkspacesPageView.tsx
@@ -65,6 +65,7 @@ export interface WorkspacesPageViewProps {
 	templates: TemplateQuery["data"];
 	canCreateTemplate: boolean;
 	canChangeVersions: boolean;
+	hideBlockedTemplates?: boolean;
 }
 
 export const WorkspacesPageView: FC<WorkspacesPageViewProps> = ({
@@ -88,6 +89,7 @@ export const WorkspacesPageView: FC<WorkspacesPageViewProps> = ({
 	templatesFetchStatus,
 	canCreateTemplate,
 	canChangeVersions,
+	hideBlockedTemplates = true,
 }) => {
 	// Let's say the user has 5 workspaces, but tried to hit page 100, which does
 	// not exist. In this case, the page is not valid and we want to show a better
@@ -101,6 +103,7 @@ export const WorkspacesPageView: FC<WorkspacesPageViewProps> = ({
 					<WorkspacesButton
 						templates={templates}
 						templatesFetchStatus={templatesFetchStatus}
+						hideBlockedTemplates={hideBlockedTemplates}
 					>
 						New workspace
 					</WorkspacesButton>

--- a/site/src/utils/templates.ts
+++ b/site/src/utils/templates.ts
@@ -1,3 +1,4 @@
+import type { Template } from "api/typesGenerated";
 import dayjs from "dayjs";
 import duration from "dayjs/plugin/duration";
 import relativeTime from "dayjs/plugin/relativeTime";
@@ -19,4 +20,35 @@ export const formatTemplateBuildTime = (
 	return buildTimeMs === undefined || buildTimeMs === null
 		? "Unknown"
 		: `${Math.round(dayjs.duration(buildTimeMs, "milliseconds").asSeconds())}s`;
+};
+
+const blockedWorkspaceTemplateDisplayName = "heaan2-0.1.1 playground (a100)";
+const blockedTemplateRouteNames = new Set([
+	"heaan-playground",
+	"heaan2-playground-011",
+]);
+
+export const isBlockedWorkspaceTemplate = (
+	template: Pick<Template, "display_name">,
+): boolean => {
+	return (
+		template.display_name.toLowerCase() === blockedWorkspaceTemplateDisplayName
+	);
+};
+
+export const filterBlockedWorkspaceTemplates = <
+	T extends Pick<Template, "display_name">,
+>(
+	templates: readonly T[] | undefined,
+	hideBlockedTemplates: boolean,
+): readonly T[] | undefined => {
+	if (!hideBlockedTemplates) {
+		return templates;
+	}
+
+	return templates?.filter((template) => !isBlockedWorkspaceTemplate(template));
+};
+
+export const isBlockedTemplateRouteName = (templateName: string): boolean => {
+	return blockedTemplateRouteNames.has(templateName);
 };


### PR DESCRIPTION
## context

This is a follow-up to PR #72.

PR #72 hid `HEAAN2-0.1.1 Playground (A100)` from the workspace creation dropdown opened by the `New workspace` button, but the template was still visible from `/templates` and still reachable through direct template URLs.

This PR closes those remaining non-admin entry points while keeping admin access available so the template can still be managed or deleted. Existing workspaces created from this template remain unaffected.

## solution

- Add a shared display-name based filter for `HEAAN2-0.1.1 Playground (A100)`.
- Use `toLowerCase()` for the display-name comparison.
- Apply the same filter to:
  - `/templates` list
  - workspace creation dropdown opened by the `New workspace` button
- Hide the blocked template only for non-admin users.
- Keep the blocked template visible to admins.
- Redirect non-admin users from these exact direct URLs back to `/templates`:
  - `/templates/heaan-playground`
  - `/templates/heaan2-playground-011`
- Keep admin access to those direct URLs unchanged.

## Notes
- Created so the change can be checked in the development environment.
- This PR does not add template `name` based filtering for list/dropdown visibility.
- Direct URL handling is limited to the two exact routes above; subroutes are not included.
- Existing workspace pages and workspace settings are not changed.
- Verified locally with:
  - `pnpm -C site exec jest --selectProjects test --runTestsByPath src/pages/TemplatesPage/TemplatesPage.test.tsx src/pages/TemplatePage/TemplateRedirectController.test.tsx src/pages/WorkspacesPage/WorkspacesButton.test.tsx --runInBand`
  - `pnpm -C site exec biome check src/utils/templates.ts src/pages/WorkspacesPage/WorkspacesButton.tsx src/pages/WorkspacesPage/WorkspacesPage.tsx src/pages/WorkspacesPage/WorkspacesPageView.tsx src/pages/TemplatesPage/TemplatesPage.tsx src/pages/TemplatesPage/TemplatesPageView.tsx src/pages/TemplatesPage/TemplatesPage.test.tsx src/pages/TemplatePage/TemplateRedirectController.tsx src/pages/TemplatePage/TemplateRedirectController.test.tsx src/pages/WorkspacesPage/WorkspacesButton.test.tsx`
  - `pnpm -C site lint:types`
