### PR TITLE
Hide blocked template from empty workspace suggestions

### DIFF
--- a/site/src/pages/WorkspacesPage/WorkspacesButton.tsx
+++ b/site/src/pages/WorkspacesPage/WorkspacesButton.tsx
@@ -22,7 +22,7 @@ import {
 } from "react-router-dom";
 import { filterBlockedWorkspaceTemplates } from "utils/templates";
 
-type TemplatesQuery = UseQueryResult<Template[]>;
+type TemplatesQuery = UseQueryResult<readonly Template[]>;
 
 interface WorkspacesButtonProps {
 	children?: ReactNode;

--- a/site/src/pages/WorkspacesPage/WorkspacesEmpty.tsx
+++ b/site/src/pages/WorkspacesPage/WorkspacesEmpty.tsx
@@ -9,7 +9,7 @@ import { Link } from "react-router-dom";
 
 interface WorkspacesEmptyProps {
 	isUsingFilter: boolean;
-	templates?: Template[];
+	templates?: readonly Template[];
 	canCreateTemplate: boolean;
 }
 

--- a/site/src/pages/WorkspacesPage/WorkspacesPageView.test.tsx
+++ b/site/src/pages/WorkspacesPage/WorkspacesPageView.test.tsx
@@ -1,0 +1,171 @@
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import type { Template } from "api/typesGenerated";
+import { ThemeProvider } from "contexts/ThemeProvider";
+import { DashboardContext } from "modules/dashboard/DashboardProvider";
+import { type ComponentProps, act } from "react";
+import { RouterProvider, createMemoryRouter } from "react-router-dom";
+import {
+	MockAppearanceConfig,
+	MockDefaultOrganization,
+	MockEntitlements,
+	MockExperiments,
+	MockTemplate,
+	MockWorkspace,
+} from "testHelpers/entities";
+import { WorkspacesPageView } from "./WorkspacesPageView";
+
+jest.mock("components/Filter/UserFilter", () => ({
+	UserMenu: () => null,
+}));
+
+describe("WorkspacesPageView", () => {
+	afterEach(() => {
+		jest.useRealTimers();
+	});
+
+	it("hides blocked templates from the empty workspaces suggestions", () => {
+		const blockedTemplate: Template = {
+			...MockTemplate,
+			id: "heaan2-011-a100",
+			name: "heaan2-011-a100",
+			display_name: "HEAAN2-0.1.1 Playground (A100)",
+		};
+		const enabledTemplate: Template = {
+			...MockTemplate,
+			id: "heaan2-020-a100",
+			name: "heaan2-020-a100",
+			display_name: "HEaaN2-0.2.0 Playground (A100)",
+		};
+
+		renderWorkspacesPageView({
+			templates: [blockedTemplate, enabledTemplate],
+			workspaces: [],
+			count: 0,
+			hideBlockedTemplates: true,
+		});
+
+		expect(
+			screen.queryByText("HEAAN2-0.1.1 Playground (A100)"),
+		).not.toBeInTheDocument();
+		expect(
+			screen.getByText("HEaaN2-0.2.0 Playground (A100)").closest("a"),
+		).toHaveAttribute("href", "/templates/heaan2-020-a100/workspace");
+	});
+
+	it("keeps blocked templates in the new workspace menu when filtering is disabled", async () => {
+		jest.useFakeTimers();
+		const user = userEvent.setup({ advanceTimers: jest.advanceTimersByTime });
+		const blockedTemplate: Template = {
+			...MockTemplate,
+			id: "heaan2-011-a100",
+			name: "heaan2-011-a100",
+			display_name: "HEAAN2-0.1.1 Playground (A100)",
+		};
+
+		renderWorkspacesPageView({
+			templates: [blockedTemplate],
+			workspaces: [MockWorkspace],
+			count: 1,
+			hideBlockedTemplates: false,
+		});
+
+		await act(async () => {
+			await user.click(screen.getByRole("button", { name: /new workspace/i }));
+		});
+		await act(async () => {
+			jest.runOnlyPendingTimers();
+		});
+
+		expect(
+			screen.getByText("HEAAN2-0.1.1 Playground (A100)").closest("a"),
+		).toHaveAttribute("href", "/templates/heaan2-011-a100/workspace");
+	});
+});
+
+type WorkspacesPageViewProps = ComponentProps<typeof WorkspacesPageView>;
+
+const menu = {
+	initialOption: undefined,
+	isInitializing: false,
+	isSearching: false,
+	query: "",
+	searchOptions: [],
+	selectedOption: undefined,
+	selectOption: jest.fn(),
+	setQuery: jest.fn(),
+};
+
+const filterProps: WorkspacesPageViewProps["filterProps"] = {
+	filter: {
+		query: "owner:me",
+		update: jest.fn(),
+		debounceUpdate: jest.fn(),
+		cancelDebounce: jest.fn(),
+		used: false,
+		values: {
+			owner: "me",
+			status: undefined,
+			template: undefined,
+		},
+	},
+	menus: {
+		user: menu,
+		template: menu,
+		status: menu,
+		organizations: menu,
+	},
+};
+
+function renderWorkspacesPageView(
+	overrides: Partial<WorkspacesPageViewProps> = {},
+) {
+	render(
+		<ThemeProvider>
+			<DashboardContext.Provider
+				value={{
+					entitlements: MockEntitlements,
+					experiments: MockExperiments,
+					appearance: MockAppearanceConfig,
+					organizations: [MockDefaultOrganization],
+					showOrganizations: false,
+				}}
+			>
+				<RouterProvider
+					router={createMemoryRouter(
+						[
+							{
+								path: "/",
+								element: (
+									<WorkspacesPageView
+										error={undefined}
+										checkedWorkspaces={[]}
+										count={0}
+										filterProps={filterProps}
+										page={1}
+										limit={25}
+										onPageChange={jest.fn()}
+										onUpdateWorkspace={jest.fn()}
+										onCheckChange={jest.fn()}
+										isRunningBatchAction={false}
+										onDeleteAll={jest.fn()}
+										onUpdateAll={jest.fn()}
+										onStartAll={jest.fn()}
+										onStopAll={jest.fn()}
+										canCheckWorkspaces={false}
+										templatesFetchStatus="success"
+										templates={[]}
+										canCreateTemplate={false}
+										canChangeVersions={false}
+										{...overrides}
+									/>
+								),
+							},
+						],
+						{ initialEntries: ["/"] },
+					)}
+				/>
+			</DashboardContext.Provider>
+		</ThemeProvider>,
+	);
+}

--- a/site/src/pages/WorkspacesPage/WorkspacesPageView.tsx
+++ b/site/src/pages/WorkspacesPage/WorkspacesPageView.tsx
@@ -25,6 +25,7 @@ import { TableToolbar } from "components/TableToolbar/TableToolbar";
 import { WorkspacesTable } from "pages/WorkspacesPage/WorkspacesTable";
 import type { FC } from "react";
 import type { UseQueryResult } from "react-query";
+import { filterBlockedWorkspaceTemplates } from "utils/templates";
 import { mustUpdateWorkspace } from "utils/workspace";
 import { WorkspaceHelpTooltip } from "./WorkspaceHelpTooltip";
 import { WorkspacesButton } from "./WorkspacesButton";
@@ -91,6 +92,10 @@ export const WorkspacesPageView: FC<WorkspacesPageViewProps> = ({
 	canChangeVersions,
 	hideBlockedTemplates = true,
 }) => {
+	const visibleTemplates = filterBlockedWorkspaceTemplates(
+		templates,
+		hideBlockedTemplates,
+	);
 	// Let's say the user has 5 workspaces, but tried to hit page 100, which does
 	// not exist. In this case, the page is not valid and we want to show a better
 	// error message.
@@ -101,7 +106,7 @@ export const WorkspacesPageView: FC<WorkspacesPageViewProps> = ({
 			<PageHeader
 				actions={
 					<WorkspacesButton
-						templates={templates}
+						templates={visibleTemplates}
 						templatesFetchStatus={templatesFetchStatus}
 						hideBlockedTemplates={hideBlockedTemplates}
 					>
@@ -223,7 +228,7 @@ export const WorkspacesPageView: FC<WorkspacesPageViewProps> = ({
 					checkedWorkspaces={checkedWorkspaces}
 					onCheckChange={onCheckChange}
 					canCheckWorkspaces={canCheckWorkspaces}
-					templates={templates}
+					templates={visibleTemplates}
 				/>
 			)}
 

--- a/site/src/pages/WorkspacesPage/WorkspacesTable.tsx
+++ b/site/src/pages/WorkspacesPage/WorkspacesTable.tsx
@@ -39,7 +39,7 @@ export interface WorkspacesTableProps {
 	onUpdateWorkspace: (workspace: Workspace) => void;
 	onCheckChange: (checkedWorkspaces: readonly Workspace[]) => void;
 	canCheckWorkspaces: boolean;
-	templates?: Template[];
+	templates?: readonly Template[];
 	canCreateTemplate: boolean;
 }
 


### PR DESCRIPTION
## context

This is a follow-up to PR #72.

PR #72 hid `HEAAN2-0.1.1 Playground (A100)` from non-admin template list, workspace creation dropdown, and exact direct template URLs, but **the empty workspaces state** still rendered featured template suggestions from the unfiltered template list.

That meant non-admin users with no workspaces could still see and select the blocked template from the empty workspaces page.

## solution

- Reuse the shared display-name based filter for `HEAAN2-0.1.1 Playground (A100)` in the workspaces page view.
- Apply the filtered template list consistently to:
  - workspace creation dropdown opened by the `New workspace` button
  - empty workspaces featured template suggestions
- Hide the blocked template only for non-admin users.
- Keep the blocked template visible to admins.

## Notes

- Created so the change can be checked in the development environment.
- This PR does not add template `name` based filtering for list/dropdown visibility.
- Direct URL handling is not changed in this PR.
- Existing workspace pages and workspace settings are not changed.
- Verified locally with:
  - `pnpm -C site exec jest --selectProjects test --runTestsByPath src/pages/WorkspacesPage/WorkspacesPageView.test.tsx src/pages/WorkspacesPage/WorkspacesButton.test.tsx --runInBand`
  - `pnpm -C site exec biome check --error-on-warnings src/pages/WorkspacesPage/WorkspacesPageView.tsx src/pages/WorkspacesPage/WorkspacesButton.tsx src/pages/WorkspacesPage/WorkspacesTable.tsx src/pages/WorkspacesPage/WorkspacesEmpty.tsx src/pages/WorkspacesPage/WorkspacesPageView.test.tsx`
  - `pnpm -C site lint:types`
- Full site Jest was also attempted with `pnpm -C site exec jest --selectProjects test --runInBand`, but the current baseline fails outside this change, including existing `import.meta` parsing failures around `RequireAuth.tsx` and existing `api.test.ts` failures. => 별도 브랜치에서 해결 예정
