### PR TITLE
temp: hide blocked HEAAN2 template from non-admin entry points

### DIFF
--- a/site/src/pages/TemplatePage/TemplateRedirectController.test.tsx
+++ b/site/src/pages/TemplatePage/TemplateRedirectController.test.tsx
@@ -1,14 +1,70 @@
-import { waitFor } from "@testing-library/react";
-import { API } from "api/api";
+import { render, waitFor } from "@testing-library/react";
+import { AuthContext } from "contexts/auth/AuthProvider";
+import type { Permissions } from "contexts/auth/permissions";
+import { DashboardContext } from "modules/dashboard/DashboardProvider";
+import { RouterProvider, createMemoryRouter } from "react-router-dom";
 import * as M from "testHelpers/entities";
-import { renderWithAuth } from "testHelpers/renderHelpers";
 import { TemplateRedirectController } from "./TemplateRedirectController";
 
-const renderTemplateRedirectController = (route: string) => {
-	return renderWithAuth(<TemplateRedirectController />, {
-		route,
-		path: "/templates/:organization?/:template",
-	});
+const renderTemplateRedirectController = (
+	route: string,
+	options: {
+		permissionOverrides?: Partial<Permissions>;
+		showOrganizations?: boolean;
+		organizations?: (typeof M.MockDefaultOrganization)[];
+	} = {},
+) => {
+	const router = createMemoryRouter(
+		[
+			{
+				path: "/templates/:organization?/:template",
+				element: <TemplateRedirectController />,
+			},
+			{
+				path: "/templates",
+				element: <div />,
+			},
+		],
+		{ initialEntries: [route] },
+	);
+
+	render(
+		<AuthContext.Provider
+			value={{
+				isLoading: false,
+				isSignedOut: false,
+				isSigningOut: false,
+				isConfiguringTheFirstUser: false,
+				isSignedIn: true,
+				isSigningIn: false,
+				isUpdatingProfile: false,
+				user: M.MockUser,
+				permissions: {
+					...M.MockPermissions,
+					...options.permissionOverrides,
+				},
+				signInError: undefined,
+				updateProfileError: undefined,
+				signOut: jest.fn(),
+				signIn: jest.fn(),
+				updateProfile: jest.fn(),
+			}}
+		>
+			<DashboardContext.Provider
+				value={{
+					entitlements: M.MockEntitlements,
+					experiments: M.MockExperiments,
+					appearance: M.MockAppearanceConfig,
+					organizations: options.organizations ?? [M.MockDefaultOrganization],
+					showOrganizations: options.showOrganizations ?? false,
+				}}
+			>
+				<RouterProvider router={router} />
+			</DashboardContext.Provider>
+		</AuthContext.Provider>,
+	);
+
+	return { router };
 };
 
 it("redirects from multi-org to single-org", async () => {
@@ -24,12 +80,12 @@ it("redirects from multi-org to single-org", async () => {
 });
 
 it("redirects from single-org to multi-org", async () => {
-	jest
-		.spyOn(API, "getOrganizations")
-		.mockResolvedValueOnce([M.MockDefaultOrganization, M.MockOrganization2]);
-
 	const { router } = renderTemplateRedirectController(
 		`/templates/${M.MockTemplate.name}`,
+		{
+			organizations: [M.MockDefaultOrganization, M.MockOrganization2],
+			showOrganizations: true,
+		},
 	);
 
 	await waitFor(() =>
@@ -38,3 +94,27 @@ it("redirects from single-org to multi-org", async () => {
 		),
 	);
 });
+
+it.each(["/templates/heaan-playground", "/templates/heaan2-playground-011"])(
+	"redirects non-admins from blocked template URL %s",
+	async (route) => {
+		const { router } = renderTemplateRedirectController(route, {
+			permissionOverrides: { deleteTemplates: false },
+		});
+
+		await waitFor(() =>
+			expect(router.state.location.pathname).toBe("/templates"),
+		);
+	},
+);
+
+it.each(["/templates/heaan-playground", "/templates/heaan2-playground-011"])(
+	"allows admins to open blocked template URL %s",
+	async (route) => {
+		const { router } = renderTemplateRedirectController(route, {
+			permissionOverrides: { deleteTemplates: true },
+		});
+
+		await waitFor(() => expect(router.state.location.pathname).toBe(route));
+	},
+);

--- a/site/src/pages/TemplatePage/TemplateRedirectController.tsx
+++ b/site/src/pages/TemplatePage/TemplateRedirectController.tsx
@@ -1,15 +1,27 @@
 import type { Organization } from "api/typesGenerated";
+import { useAuthContext } from "contexts/auth/AuthProvider";
 import { useDashboard } from "modules/dashboard/useDashboard";
 import type { FC } from "react";
 import { Navigate, Outlet, useLocation, useParams } from "react-router-dom";
+import { isBlockedTemplateRouteName } from "utils/templates";
 
 export const TemplateRedirectController: FC = () => {
 	const { organizations, showOrganizations } = useDashboard();
+	const { permissions } = useAuthContext();
 	const { organization, template } = useParams() as {
 		organization?: string;
 		template: string;
 	};
 	const location = useLocation();
+
+	if (
+		!permissions?.deleteTemplates &&
+		!organization &&
+		isBlockedTemplateRouteName(template) &&
+		location.pathname === `/templates/${template}`
+	) {
+		return <Navigate to="/templates" replace />;
+	}
 
 	// We redirect templates without an organization to the default organization,
 	// as that's likely what any links floating around expect.

--- a/site/src/pages/TemplatesPage/TemplatesPage.test.tsx
+++ b/site/src/pages/TemplatesPage/TemplatesPage.test.tsx
@@ -1,42 +1,155 @@
 import { render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
-import { AppProviders } from "App";
-import { RequireAuth } from "contexts/auth/RequireAuth";
+import type { Template } from "api/typesGenerated";
+import type { UseFilterResult } from "components/Filter/Filter";
+import { ThemeProvider } from "contexts/ThemeProvider";
+import { DashboardContext } from "modules/dashboard/DashboardProvider";
+import { act } from "react";
+import { HelmetProvider } from "react-helmet-async";
+import { QueryClient, QueryClientProvider } from "react-query";
 import { RouterProvider, createMemoryRouter } from "react-router-dom";
-import TemplatesPage from "./TemplatesPage";
+import {
+	MockAppearanceConfig,
+	MockDefaultOrganization,
+	MockEntitlements,
+	MockExperiments,
+	MockTemplate,
+} from "testHelpers/entities";
+import { TemplatesPageView } from "./TemplatesPageView";
 
 test("create template from scratch", async () => {
 	const user = userEvent.setup();
-	const router = createMemoryRouter(
-		[
+	const router = renderTemplatesPage({
+		extraRoutes: [
 			{
-				element: <RequireAuth />,
-				children: [
-					{
-						path: "/templates",
-						element: <TemplatesPage />,
-					},
-					{
-						path: "/templates/new",
-						element: <div data-testid="new-template-page" />,
-					},
-				],
+				path: "/templates/new",
+				element: <div data-testid="new-template-page" />,
 			},
 		],
-		{ initialEntries: ["/templates"] },
-	);
-	render(
-		<AppProviders>
-			<RouterProvider router={router} />
-		</AppProviders>,
-	);
+	});
+
 	const createTemplateButton = await screen.findByRole("button", {
 		name: "Create Template",
 	});
-	await user.click(createTemplateButton);
+	await act(async () => {
+		await user.click(createTemplateButton);
+	});
 	const fromScratchMenuItem = await screen.findByText("From scratch");
-	await user.click(fromScratchMenuItem);
+	await act(async () => {
+		await user.click(fromScratchMenuItem);
+	});
+
 	await screen.findByTestId("new-template-page");
 	expect(router.state.location.pathname).toBe("/templates/new");
 	expect(router.state.location.search).toBe("?exampleId=scratch");
 });
+
+test("hides the blocked template from non-admin users", async () => {
+	renderTemplatesPage({
+		templates: heaanTemplates,
+		hideBlockedTemplates: true,
+	});
+
+	await screen.findByText("Visible Template");
+	expect(
+		screen.queryByText("HEAAN2-0.1.1 Playground (A100)"),
+	).not.toBeInTheDocument();
+});
+
+test("shows the blocked template to admins", async () => {
+	renderTemplatesPage({
+		templates: heaanTemplates,
+		hideBlockedTemplates: false,
+	});
+
+	await screen.findByText("Visible Template");
+	expect(
+		await screen.findByText("HEAAN2-0.1.1 Playground (A100)"),
+	).toBeInTheDocument();
+});
+
+const heaanTemplates = [
+	{
+		...MockTemplate,
+		id: "blocked-heaan2-011",
+		name: "heaan2-011-a100",
+		display_name: "HEAAN2-0.1.1 Playground (A100)",
+	},
+	{
+		...MockTemplate,
+		id: "visible-heaan2-020",
+		name: "heaan2-020-a100",
+		display_name: "Visible Template",
+	},
+];
+
+const renderTemplatesPage = ({
+	templates = [MockTemplate],
+	hideBlockedTemplates = false,
+	extraRoutes = [],
+}: {
+	templates?: Template[];
+	hideBlockedTemplates?: boolean;
+	extraRoutes?: Parameters<typeof createMemoryRouter>[0];
+} = {}) => {
+	const router = createMemoryRouter(
+		[
+			{
+				path: "/templates",
+				element: (
+					<TemplatesPageView
+						error={undefined}
+						filter={mockFilter}
+						showOrganizations={false}
+						canCreateTemplates={true}
+						examples={[]}
+						templates={templates}
+						hideBlockedTemplates={hideBlockedTemplates}
+					/>
+				),
+			},
+			...extraRoutes,
+		],
+		{ initialEntries: ["/templates"] },
+	);
+	const queryClient = new QueryClient({
+		defaultOptions: {
+			queries: {
+				retry: false,
+				cacheTime: 0,
+				refetchOnWindowFocus: false,
+			},
+		},
+	});
+
+	render(
+		<HelmetProvider>
+			<QueryClientProvider client={queryClient}>
+				<ThemeProvider>
+					<DashboardContext.Provider
+						value={{
+							entitlements: MockEntitlements,
+							experiments: MockExperiments,
+							appearance: MockAppearanceConfig,
+							organizations: [MockDefaultOrganization],
+							showOrganizations: false,
+						}}
+					>
+						<RouterProvider router={router} />
+					</DashboardContext.Provider>
+				</ThemeProvider>
+			</QueryClientProvider>
+		</HelmetProvider>,
+	);
+
+	return router;
+};
+
+const mockFilter = {
+	query: "deprecated:false",
+	values: { deprecated: "false" },
+	update: jest.fn(),
+	debounceUpdate: jest.fn(),
+	cancelDebounce: jest.fn(),
+	used: false,
+} satisfies UseFilterResult;

--- a/site/src/pages/TemplatesPage/TemplatesPage.tsx
+++ b/site/src/pages/TemplatesPage/TemplatesPage.tsx
@@ -39,6 +39,7 @@ export const TemplatesPage: FC = () => {
 				canCreateTemplates={permissions.createTemplates}
 				examples={examplesQuery.data}
 				templates={templatesQuery.data}
+				hideBlockedTemplates={!permissions.deleteTemplates}
 			/>
 		</>
 	);

--- a/site/src/pages/TemplatesPage/TemplatesPageView.tsx
+++ b/site/src/pages/TemplatesPage/TemplatesPageView.tsx
@@ -45,6 +45,7 @@ import { Link, useNavigate } from "react-router-dom";
 import { createDayString } from "utils/createDayString";
 import { docs } from "utils/docs";
 import {
+	filterBlockedWorkspaceTemplates,
 	formatTemplateActiveDevelopers,
 	formatTemplateBuildTime,
 } from "utils/templates";
@@ -181,6 +182,7 @@ export interface TemplatesPageViewProps {
 	canCreateTemplates: boolean;
 	examples: TemplateExample[] | undefined;
 	templates: Template[] | undefined;
+	hideBlockedTemplates?: boolean;
 }
 
 export const TemplatesPageView: FC<TemplatesPageViewProps> = ({
@@ -190,9 +192,14 @@ export const TemplatesPageView: FC<TemplatesPageViewProps> = ({
 	canCreateTemplates,
 	examples,
 	templates,
+	hideBlockedTemplates = true,
 }) => {
-	const isLoading = !templates;
-	const isEmpty = templates && templates.length === 0;
+	const visibleTemplates = filterBlockedWorkspaceTemplates(
+		templates,
+		hideBlockedTemplates,
+	);
+	const isLoading = !visibleTemplates;
+	const isEmpty = visibleTemplates && visibleTemplates.length === 0;
 	const navigate = useNavigate();
 
 	const createTemplateAction = showOrganizations ? (
@@ -248,7 +255,7 @@ export const TemplatesPageView: FC<TemplatesPageViewProps> = ({
 								examples={examples ?? []}
 							/>
 						) : (
-							templates?.map((template) => (
+							visibleTemplates?.map((template) => (
 								<TemplateRow
 									key={template.id}
 									showOrganizations={showOrganizations}

--- a/site/src/pages/WorkspacesPage/WorkspacesButton.test.tsx
+++ b/site/src/pages/WorkspacesPage/WorkspacesButton.test.tsx
@@ -19,22 +19,22 @@ describe("WorkspacesButton", () => {
 		jest.useRealTimers();
 	});
 
-	it("hides the blocked template name from the new workspace menu", async () => {
+	it("hides the blocked template display name from the new workspace menu", async () => {
 		jest.useFakeTimers();
 		const user = userEvent.setup({ advanceTimers: jest.advanceTimersByTime });
 		const blockedTemplate: Template = {
 			...MockTemplate,
 			id: "heaan2-011-a100",
-			name: "HEAAN2-0.1.1-playground-a100",
-			display_name: "Blocked A100 template",
-			active_user_count: 119,
+			name: "heaan2-011-a100",
+			display_name: "HEAAN2-0.1.1 Playground (A100)",
+			active_user_count: 120,
 		};
 		const enabledTemplate: Template = {
 			...MockTemplate,
-			id: "heaan2-current-a100",
-			name: "heaan2-current-playground-a100",
-			display_name: "HEAAN2-0.1.1 Playground (A100)",
-			active_user_count: 42,
+			id: "heaan2-020-a100",
+			name: "heaan2-020-a100",
+			display_name: "HEaaN2-0.2.0 Playground (A100)",
+			active_user_count: 101,
 		};
 
 		renderWorkspacesButton(
@@ -53,13 +53,12 @@ describe("WorkspacesButton", () => {
 			jest.runOnlyPendingTimers();
 		});
 
-		expect(screen.queryByText("Blocked A100 template")).not.toBeInTheDocument();
 		expect(
-			screen.getByText("HEAAN2-0.1.1 Playground (A100)").closest("a"),
-		).toHaveAttribute(
-			"href",
-			"/templates/heaan2-current-playground-a100/workspace",
-		);
+			screen.queryByText("HEAAN2-0.1.1 Playground (A100)"),
+		).not.toBeInTheDocument();
+		expect(
+			screen.getByText("HEaaN2-0.2.0 Playground (A100)").closest("a"),
+		).toHaveAttribute("href", "/templates/heaan2-020-a100/workspace");
 	});
 });
 

--- a/site/src/pages/WorkspacesPage/WorkspacesButton.test.tsx
+++ b/site/src/pages/WorkspacesPage/WorkspacesButton.test.tsx
@@ -1,0 +1,86 @@
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import type { Template } from "api/typesGenerated";
+import { ThemeProvider } from "contexts/ThemeProvider";
+import { DashboardContext } from "modules/dashboard/DashboardProvider";
+import { act } from "react";
+import { RouterProvider, createMemoryRouter } from "react-router-dom";
+import {
+	MockAppearanceConfig,
+	MockDefaultOrganization,
+	MockEntitlements,
+	MockExperiments,
+	MockTemplate,
+} from "testHelpers/entities";
+import { WorkspacesButton } from "./WorkspacesButton";
+
+describe("WorkspacesButton", () => {
+	afterEach(() => {
+		jest.useRealTimers();
+	});
+
+	it("hides the blocked template name from the new workspace menu", async () => {
+		jest.useFakeTimers();
+		const user = userEvent.setup({ advanceTimers: jest.advanceTimersByTime });
+		const blockedTemplate: Template = {
+			...MockTemplate,
+			id: "heaan2-011-a100",
+			name: "HEAAN2-0.1.1-playground-a100",
+			display_name: "Blocked A100 template",
+			active_user_count: 119,
+		};
+		const enabledTemplate: Template = {
+			...MockTemplate,
+			id: "heaan2-current-a100",
+			name: "heaan2-current-playground-a100",
+			display_name: "HEAAN2-0.1.1 Playground (A100)",
+			active_user_count: 42,
+		};
+
+		renderWorkspacesButton(
+			<WorkspacesButton
+				templates={[blockedTemplate, enabledTemplate]}
+				templatesFetchStatus="success"
+			>
+				New workspace
+			</WorkspacesButton>,
+		);
+
+		await act(async () => {
+			await user.click(screen.getByRole("button", { name: /new workspace/i }));
+		});
+		await act(async () => {
+			jest.runOnlyPendingTimers();
+		});
+
+		expect(screen.queryByText("Blocked A100 template")).not.toBeInTheDocument();
+		expect(
+			screen.getByText("HEAAN2-0.1.1 Playground (A100)").closest("a"),
+		).toHaveAttribute(
+			"href",
+			"/templates/heaan2-current-playground-a100/workspace",
+		);
+	});
+});
+
+function renderWorkspacesButton(element: JSX.Element) {
+	render(
+		<ThemeProvider>
+			<DashboardContext.Provider
+				value={{
+					entitlements: MockEntitlements,
+					experiments: MockExperiments,
+					appearance: MockAppearanceConfig,
+					organizations: [MockDefaultOrganization],
+					showOrganizations: false,
+				}}
+			>
+				<RouterProvider
+					router={createMemoryRouter([{ path: "/", element }], {
+						initialEntries: ["/"],
+					})}
+				/>
+			</DashboardContext.Provider>
+		</ThemeProvider>,
+	);
+}

--- a/site/src/pages/WorkspacesPage/WorkspacesButton.test.tsx
+++ b/site/src/pages/WorkspacesPage/WorkspacesButton.test.tsx
@@ -60,6 +60,39 @@ describe("WorkspacesButton", () => {
 			screen.getByText("HEaaN2-0.2.0 Playground (A100)").closest("a"),
 		).toHaveAttribute("href", "/templates/heaan2-020-a100/workspace");
 	});
+
+	it("shows the blocked template when blocked template filtering is disabled", async () => {
+		jest.useFakeTimers();
+		const user = userEvent.setup({ advanceTimers: jest.advanceTimersByTime });
+		const blockedTemplate: Template = {
+			...MockTemplate,
+			id: "heaan2-011-a100",
+			name: "heaan2-011-a100",
+			display_name: "HEAAN2-0.1.1 Playground (A100)",
+			active_user_count: 120,
+		};
+
+		renderWorkspacesButton(
+			<WorkspacesButton
+				templates={[blockedTemplate]}
+				templatesFetchStatus="success"
+				hideBlockedTemplates={false}
+			>
+				New workspace
+			</WorkspacesButton>,
+		);
+
+		await act(async () => {
+			await user.click(screen.getByRole("button", { name: /new workspace/i }));
+		});
+		await act(async () => {
+			jest.runOnlyPendingTimers();
+		});
+
+		expect(
+			screen.getByText("HEAAN2-0.1.1 Playground (A100)").closest("a"),
+		).toHaveAttribute("href", "/templates/heaan2-011-a100/workspace");
+	});
 });
 
 function renderWorkspacesButton(element: JSX.Element) {

--- a/site/src/pages/WorkspacesPage/WorkspacesButton.tsx
+++ b/site/src/pages/WorkspacesPage/WorkspacesButton.tsx
@@ -37,7 +37,13 @@ export const WorkspacesButton: FC<WorkspacesButtonProps> = ({
 	// Dataset should always be small enough that client-side filtering should be
 	// good enough. Can swap out down the line if it becomes an issue
 	const [searchTerm, setSearchTerm] = useState("");
-	const processed = sortTemplatesByUsersDesc(templates ?? [], searchTerm);
+	const processed = sortTemplatesByUsersDesc(
+		(templates ?? []).filter(
+			(template) =>
+				template.name.toLowerCase() !== "heaan2-0.1.1-playground-a100",
+		),
+		searchTerm,
+	);
 
 	let emptyState: ReactNode = undefined;
 	if (templates?.length === 0) {

--- a/site/src/pages/WorkspacesPage/WorkspacesButton.tsx
+++ b/site/src/pages/WorkspacesPage/WorkspacesButton.tsx
@@ -20,6 +20,7 @@ import {
 	Link as RouterLink,
 	type LinkProps as RouterLinkProps,
 } from "react-router-dom";
+import { filterBlockedWorkspaceTemplates } from "utils/templates";
 
 type TemplatesQuery = UseQueryResult<Template[]>;
 
@@ -27,22 +28,21 @@ interface WorkspacesButtonProps {
 	children?: ReactNode;
 	templatesFetchStatus: TemplatesQuery["status"];
 	templates: TemplatesQuery["data"];
+	hideBlockedTemplates?: boolean;
 }
 
 export const WorkspacesButton: FC<WorkspacesButtonProps> = ({
 	children,
 	templatesFetchStatus,
 	templates,
+	hideBlockedTemplates = true,
 }) => {
 	// Dataset should always be small enough that client-side filtering should be
 	// good enough. Can swap out down the line if it becomes an issue
 	const [searchTerm, setSearchTerm] = useState("");
 	const processed = sortTemplatesByUsersDesc(
-		(templates ?? []).filter(
-			(template) =>
-				(template.display_name || template.name).toLowerCase() !==
-				"heaan2-0.1.1 playground (a100)",
-		),
+		filterBlockedWorkspaceTemplates(templates ?? [], hideBlockedTemplates) ??
+			[],
 		searchTerm,
 	);
 

--- a/site/src/pages/WorkspacesPage/WorkspacesButton.tsx
+++ b/site/src/pages/WorkspacesPage/WorkspacesButton.tsx
@@ -22,7 +22,7 @@ import {
 } from "react-router-dom";
 import { filterBlockedWorkspaceTemplates } from "utils/templates";
 
-type TemplatesQuery = UseQueryResult<Template[]>;
+type TemplatesQuery = UseQueryResult<readonly Template[]>;
 
 interface WorkspacesButtonProps {
 	children?: ReactNode;

--- a/site/src/pages/WorkspacesPage/WorkspacesButton.tsx
+++ b/site/src/pages/WorkspacesPage/WorkspacesButton.tsx
@@ -40,7 +40,8 @@ export const WorkspacesButton: FC<WorkspacesButtonProps> = ({
 	const processed = sortTemplatesByUsersDesc(
 		(templates ?? []).filter(
 			(template) =>
-				template.name.toLowerCase() !== "heaan2-0.1.1-playground-a100",
+				(template.display_name || template.name).toLowerCase() !==
+				"heaan2-0.1.1 playground (a100)",
 		),
 		searchTerm,
 	);

--- a/site/src/pages/WorkspacesPage/WorkspacesEmpty.tsx
+++ b/site/src/pages/WorkspacesPage/WorkspacesEmpty.tsx
@@ -9,7 +9,7 @@ import { Link } from "react-router-dom";
 
 interface WorkspacesEmptyProps {
 	isUsingFilter: boolean;
-	templates?: Template[];
+	templates?: readonly Template[];
 	canCreateTemplate: boolean;
 }
 

--- a/site/src/pages/WorkspacesPage/WorkspacesPage.tsx
+++ b/site/src/pages/WorkspacesPage/WorkspacesPage.tsx
@@ -94,6 +94,7 @@ const WorkspacesPage: FC = () => {
 				templatesFetchStatus={templatesQuery.status}
 				workspaces={data?.workspaces}
 				error={error}
+				hideBlockedTemplates={!permissions.deleteTemplates}
 				count={data?.count}
 				page={pagination.page}
 				limit={pagination.limit}

--- a/site/src/pages/WorkspacesPage/WorkspacesPageView.test.tsx
+++ b/site/src/pages/WorkspacesPage/WorkspacesPageView.test.tsx
@@ -1,0 +1,171 @@
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import type { Template } from "api/typesGenerated";
+import { ThemeProvider } from "contexts/ThemeProvider";
+import { DashboardContext } from "modules/dashboard/DashboardProvider";
+import { type ComponentProps, act } from "react";
+import { RouterProvider, createMemoryRouter } from "react-router-dom";
+import {
+	MockAppearanceConfig,
+	MockDefaultOrganization,
+	MockEntitlements,
+	MockExperiments,
+	MockTemplate,
+	MockWorkspace,
+} from "testHelpers/entities";
+import { WorkspacesPageView } from "./WorkspacesPageView";
+
+jest.mock("components/Filter/UserFilter", () => ({
+	UserMenu: () => null,
+}));
+
+describe("WorkspacesPageView", () => {
+	afterEach(() => {
+		jest.useRealTimers();
+	});
+
+	it("hides blocked templates from the empty workspaces suggestions", () => {
+		const blockedTemplate: Template = {
+			...MockTemplate,
+			id: "heaan2-011-a100",
+			name: "heaan2-011-a100",
+			display_name: "HEAAN2-0.1.1 Playground (A100)",
+		};
+		const enabledTemplate: Template = {
+			...MockTemplate,
+			id: "heaan2-020-a100",
+			name: "heaan2-020-a100",
+			display_name: "HEaaN2-0.2.0 Playground (A100)",
+		};
+
+		renderWorkspacesPageView({
+			templates: [blockedTemplate, enabledTemplate],
+			workspaces: [],
+			count: 0,
+			hideBlockedTemplates: true,
+		});
+
+		expect(
+			screen.queryByText("HEAAN2-0.1.1 Playground (A100)"),
+		).not.toBeInTheDocument();
+		expect(
+			screen.getByText("HEaaN2-0.2.0 Playground (A100)").closest("a"),
+		).toHaveAttribute("href", "/templates/heaan2-020-a100/workspace");
+	});
+
+	it("keeps blocked templates in the new workspace menu when filtering is disabled", async () => {
+		jest.useFakeTimers();
+		const user = userEvent.setup({ advanceTimers: jest.advanceTimersByTime });
+		const blockedTemplate: Template = {
+			...MockTemplate,
+			id: "heaan2-011-a100",
+			name: "heaan2-011-a100",
+			display_name: "HEAAN2-0.1.1 Playground (A100)",
+		};
+
+		renderWorkspacesPageView({
+			templates: [blockedTemplate],
+			workspaces: [MockWorkspace],
+			count: 1,
+			hideBlockedTemplates: false,
+		});
+
+		await act(async () => {
+			await user.click(screen.getByRole("button", { name: /new workspace/i }));
+		});
+		await act(async () => {
+			jest.runOnlyPendingTimers();
+		});
+
+		expect(
+			screen.getByText("HEAAN2-0.1.1 Playground (A100)").closest("a"),
+		).toHaveAttribute("href", "/templates/heaan2-011-a100/workspace");
+	});
+});
+
+type WorkspacesPageViewProps = ComponentProps<typeof WorkspacesPageView>;
+
+const menu = {
+	initialOption: undefined,
+	isInitializing: false,
+	isSearching: false,
+	query: "",
+	searchOptions: [],
+	selectedOption: undefined,
+	selectOption: jest.fn(),
+	setQuery: jest.fn(),
+};
+
+const filterProps: WorkspacesPageViewProps["filterProps"] = {
+	filter: {
+		query: "owner:me",
+		update: jest.fn(),
+		debounceUpdate: jest.fn(),
+		cancelDebounce: jest.fn(),
+		used: false,
+		values: {
+			owner: "me",
+			status: undefined,
+			template: undefined,
+		},
+	},
+	menus: {
+		user: menu,
+		template: menu,
+		status: menu,
+		organizations: menu,
+	},
+};
+
+function renderWorkspacesPageView(
+	overrides: Partial<WorkspacesPageViewProps> = {},
+) {
+	render(
+		<ThemeProvider>
+			<DashboardContext.Provider
+				value={{
+					entitlements: MockEntitlements,
+					experiments: MockExperiments,
+					appearance: MockAppearanceConfig,
+					organizations: [MockDefaultOrganization],
+					showOrganizations: false,
+				}}
+			>
+				<RouterProvider
+					router={createMemoryRouter(
+						[
+							{
+								path: "/",
+								element: (
+									<WorkspacesPageView
+										error={undefined}
+										checkedWorkspaces={[]}
+										count={0}
+										filterProps={filterProps}
+										page={1}
+										limit={25}
+										onPageChange={jest.fn()}
+										onUpdateWorkspace={jest.fn()}
+										onCheckChange={jest.fn()}
+										isRunningBatchAction={false}
+										onDeleteAll={jest.fn()}
+										onUpdateAll={jest.fn()}
+										onStartAll={jest.fn()}
+										onStopAll={jest.fn()}
+										canCheckWorkspaces={false}
+										templatesFetchStatus="success"
+										templates={[]}
+										canCreateTemplate={false}
+										canChangeVersions={false}
+										{...overrides}
+									/>
+								),
+							},
+						],
+						{ initialEntries: ["/"] },
+					)}
+				/>
+			</DashboardContext.Provider>
+		</ThemeProvider>,
+	);
+}

--- a/site/src/pages/WorkspacesPage/WorkspacesPageView.tsx
+++ b/site/src/pages/WorkspacesPage/WorkspacesPageView.tsx
@@ -25,6 +25,7 @@ import { TableToolbar } from "components/TableToolbar/TableToolbar";
 import { WorkspacesTable } from "pages/WorkspacesPage/WorkspacesTable";
 import type { FC } from "react";
 import type { UseQueryResult } from "react-query";
+import { filterBlockedWorkspaceTemplates } from "utils/templates";
 import { mustUpdateWorkspace } from "utils/workspace";
 import { WorkspaceHelpTooltip } from "./WorkspaceHelpTooltip";
 import { WorkspacesButton } from "./WorkspacesButton";
@@ -91,6 +92,10 @@ export const WorkspacesPageView: FC<WorkspacesPageViewProps> = ({
 	canChangeVersions,
 	hideBlockedTemplates = true,
 }) => {
+	const visibleTemplates = filterBlockedWorkspaceTemplates(
+		templates,
+		hideBlockedTemplates,
+	);
 	// Let's say the user has 5 workspaces, but tried to hit page 100, which does
 	// not exist. In this case, the page is not valid and we want to show a better
 	// error message.
@@ -101,7 +106,7 @@ export const WorkspacesPageView: FC<WorkspacesPageViewProps> = ({
 			<PageHeader
 				actions={
 					<WorkspacesButton
-						templates={templates}
+						templates={visibleTemplates}
 						templatesFetchStatus={templatesFetchStatus}
 						hideBlockedTemplates={hideBlockedTemplates}
 					>
@@ -223,7 +228,7 @@ export const WorkspacesPageView: FC<WorkspacesPageViewProps> = ({
 					checkedWorkspaces={checkedWorkspaces}
 					onCheckChange={onCheckChange}
 					canCheckWorkspaces={canCheckWorkspaces}
-					templates={templates}
+					templates={visibleTemplates}
 				/>
 			)}
 

--- a/site/src/pages/WorkspacesPage/WorkspacesPageView.tsx
+++ b/site/src/pages/WorkspacesPage/WorkspacesPageView.tsx
@@ -65,6 +65,7 @@ export interface WorkspacesPageViewProps {
 	templates: TemplateQuery["data"];
 	canCreateTemplate: boolean;
 	canChangeVersions: boolean;
+	hideBlockedTemplates?: boolean;
 }
 
 export const WorkspacesPageView: FC<WorkspacesPageViewProps> = ({
@@ -88,6 +89,7 @@ export const WorkspacesPageView: FC<WorkspacesPageViewProps> = ({
 	templatesFetchStatus,
 	canCreateTemplate,
 	canChangeVersions,
+	hideBlockedTemplates = true,
 }) => {
 	// Let's say the user has 5 workspaces, but tried to hit page 100, which does
 	// not exist. In this case, the page is not valid and we want to show a better
@@ -101,6 +103,7 @@ export const WorkspacesPageView: FC<WorkspacesPageViewProps> = ({
 					<WorkspacesButton
 						templates={templates}
 						templatesFetchStatus={templatesFetchStatus}
+						hideBlockedTemplates={hideBlockedTemplates}
 					>
 						New workspace
 					</WorkspacesButton>

--- a/site/src/pages/WorkspacesPage/WorkspacesTable.tsx
+++ b/site/src/pages/WorkspacesPage/WorkspacesTable.tsx
@@ -39,7 +39,7 @@ export interface WorkspacesTableProps {
 	onUpdateWorkspace: (workspace: Workspace) => void;
 	onCheckChange: (checkedWorkspaces: readonly Workspace[]) => void;
 	canCheckWorkspaces: boolean;
-	templates?: Template[];
+	templates?: readonly Template[];
 	canCreateTemplate: boolean;
 }
 

--- a/site/src/testHelpers/entities.ts
+++ b/site/src/testHelpers/entities.ts
@@ -1331,6 +1331,7 @@ export const MockWorkspace: TypesGen.Workspace = {
 	organization_id: MockOrganization.id,
 	organization_name: "default",
 	owner_name: MockUser.username,
+	owner_email: MockUser.email,
 	owner_avatar_url: "https://avatars.githubusercontent.com/u/7122116?v=4",
 	autostart_schedule: MockWorkspaceAutostartEnabled.schedule,
 	ttl_ms: 2 * 60 * 60 * 1000,

--- a/site/src/utils/templates.ts
+++ b/site/src/utils/templates.ts
@@ -1,3 +1,4 @@
+import type { Template } from "api/typesGenerated";
 import dayjs from "dayjs";
 import duration from "dayjs/plugin/duration";
 import relativeTime from "dayjs/plugin/relativeTime";
@@ -19,4 +20,35 @@ export const formatTemplateBuildTime = (
 	return buildTimeMs === undefined || buildTimeMs === null
 		? "Unknown"
 		: `${Math.round(dayjs.duration(buildTimeMs, "milliseconds").asSeconds())}s`;
+};
+
+const blockedWorkspaceTemplateDisplayName = "heaan2-0.1.1 playground (a100)";
+const blockedTemplateRouteNames = new Set([
+	"heaan-playground",
+	"heaan2-playground-011",
+]);
+
+export const isBlockedWorkspaceTemplate = (
+	template: Pick<Template, "display_name">,
+): boolean => {
+	return (
+		template.display_name.toLowerCase() === blockedWorkspaceTemplateDisplayName
+	);
+};
+
+export const filterBlockedWorkspaceTemplates = <
+	T extends Pick<Template, "display_name">,
+>(
+	templates: readonly T[] | undefined,
+	hideBlockedTemplates: boolean,
+): readonly T[] | undefined => {
+	if (!hideBlockedTemplates) {
+		return templates;
+	}
+
+	return templates?.filter((template) => !isBlockedWorkspaceTemplate(template));
+};
+
+export const isBlockedTemplateRouteName = (templateName: string): boolean => {
+	return blockedTemplateRouteNames.has(templateName);
 };


### PR DESCRIPTION
## Context

⚠️This should be reverted after the 9/7 release.

This PR promotes the HEAAN2 0.1.1 A100 template visibility restrictions from `codeheaan-dev` to `codeheaan-main`.

`HEAAN2-0.1.1 Playground (A100)` should no longer be available to non-admin users as a workspace creation option. PRs #72, #73, and #74 closed the known user-facing entry points: the `New workspace` menu, the `/templates` list, exact direct template URLs, and empty-workspaces featured template suggestions.

Existing workspaces created from this template should remain visible and unaffected, and admins should still be able to access and manage the template.

## Solution

- Add and reuse a shared display-name based blocked-template filter for `HEAAN2-0.1.1 Playground (A100)`, using a case-insensitive comparison.
- Apply the filtered template list consistently to:
  - the `New workspace` template dropdown
  - the `/templates` page
  - empty workspace featured template suggestions
- Hide the blocked template only for non-admin users / Keep the blocked template visible to admins.
- Redirect non-admin users from these exact direct template routes back to `/templates`:
  - `/templates/heaan-playground`
  - `/templates/heaan2-playground-011`
- Add and extend focused site tests for the workspace dropdown, templates page, direct route redirect controller, and empty workspace suggestions.
- Add `owner_email` to the mock workspace fixture so site type checking remains green.

## Notes

- This merge includes the changes from #72, #73, and #74.
- Visibility filtering is based on template `display_name`; this does not add template `name` based filtering for list/dropdown visibility.
- Direct URL blocking is limited to the two exact routes above; subroutes are unchanged.
- Existing workspace list/detail/settings behavior is unchanged.
- Source PRs were locally verified with targeted Jest, Biome, `pnpm -C site lint:types`, and `git diff --check` where applicable.
- A full site Jest run was attempted in #74, but the current baseline fails outside this change, including existing `import.meta` parsing failures around `RequireAuth.tsx` and existing `api.test.ts` failures. These are planned for a separate branch.

## Results
<img width="200" height="250" alt="image" src="https://github.com/user-attachments/assets/d851853a-e3a7-4f68-bc0c-615450195212" />
<img width="200" height="250" alt="image" src="https://github.com/user-attachments/assets/07f43b2d-3c02-4ef1-a7a9-eeaefb92369b" />
<img width="700" height="350" alt="image" src="https://github.com/user-attachments/assets/938b4642-837c-49b9-a46f-b41d4d96b4a9" />
<img width="700" height="350" alt="image" src="https://github.com/user-attachments/assets/c44424fe-40bf-49e3-9714-c593f59e0f47" />
<img width="800" height="400" alt="image" src="https://github.com/user-attachments/assets/a4e0406d-8f1e-4340-80b0-31e3348fbc33" />
<img width="800" height="400" alt="image" src="https://github.com/user-attachments/assets/fd4697af-6ad9-41fb-89e6-4a95ef97fcdb" />

